### PR TITLE
feat(dashboard): add playoff series info to recent games and schedule

### DIFF
--- a/docker/postgres_bootstrap.sql
+++ b/docker/postgres_bootstrap.sql
@@ -3809,7 +3809,9 @@ CREATE TABLE IF NOT EXISTS schedule_season_remaining(
 	home_team_logo text NULL,
 	away_team_logo text NULL,
 	home_team_odds text NULL,
-	away_team_odds text NULL
+	away_team_odds text NULL,
+	series_round text NULL,
+	series_game_number int4 NULL
 );
 
 INSERT INTO schedule_season_remaining (game_date,day_name,game_ts,avg_team_rank,start_time,home_team,away_team,home_moneyline_raw,away_moneyline_raw,home_team_logo,away_team_logo,home_team_odds,away_team_odds) VALUES
@@ -3833,7 +3835,10 @@ CREATE TABLE IF NOT EXISTS gold.schedule_tonights_games(
 	home_team_predicted_win_pct float8 NULL,
 	away_team_predicted_win_pct float8 NULL,
 	home_is_great_value int4 NULL,
-	away_is_great_value int4 NULL
+	away_is_great_value int4 NULL,
+	series_round text NULL,
+	series_status text NULL,
+	series_game_number int4 NULL
 );
 
 INSERT INTO gold.schedule_tonights_games (home_team,away_team,avg_team_rank,home_team_odds,away_team_odds,start_time,game_date,home_moneyline,away_moneyline,home_team_predicted_win_pct,away_team_predicted_win_pct,home_is_great_value,away_is_great_value) VALUES
@@ -3849,6 +3854,14 @@ INSERT INTO gold.schedule_tonights_games (home_team,away_team,avg_team_rank,home
 	 ('Sacramento Kings','Golden State Warriors', 5, 'Sacramento Kings (-160)','Golden State Warriors (+130)','10:00 PM',current_date,-160.0,130.0,0.779,0.221,1,0);
 INSERT INTO gold.schedule_tonights_games (home_team,away_team,avg_team_rank,home_team_odds,away_team_odds,start_time,game_date,home_moneyline,away_moneyline,home_team_predicted_win_pct,away_team_predicted_win_pct,home_is_great_value,away_is_great_value) VALUES
 	 ('Portland Trail Blazers','Orlando Magic', 25.5, 'Portland Trail Blazers (+115)','Orlando Magic (-140)','10:00 PM',current_date,115.0,-140.0,0.332,0.668,0,0);
+
+-- Playoff series context (state BEFORE tonight's game). NULL outside the postseason.
+UPDATE gold.schedule_tonights_games
+SET series_round = 'NBA Finals', series_status = 'Series tied 1-1', series_game_number = 3
+WHERE home_team = 'Atlanta Hawks' AND away_team = 'New York Knicks';
+UPDATE gold.schedule_tonights_games
+SET series_round = 'Conf. Semifinals', series_status = 'BOS leads 2-1', series_game_number = 4
+WHERE home_team = 'Boston Celtics' AND away_team = 'Miami Heat';
 
 DROP TABLE IF EXISTS social_media_aggs;
 CREATE TABLE IF NOT EXISTS social_media_aggs
@@ -4857,7 +4870,10 @@ CREATE TABLE IF NOT EXISTS recent_games_teams (
 	team_logo text NULL,
 	opp_logo text NULL,
 	home_team text NULL,
-	new_loc text NULL
+	new_loc text NULL,
+	series_round text NULL,
+	series_status text NULL,
+	series_game_number int4 NULL
 );
 
 INSERT INTO recent_games_teams (team,opponent,game_date,outcome,pts_scored,pts_scored_opp,mov,max_team_lead,max_opponent_lead,team_max_score,team_avg_score,pts_color,opp_pts_color,team_logo,opp_logo,home_team,new_loc) VALUES
@@ -4876,6 +4892,17 @@ INSERT INTO recent_games_teams (team,opponent,game_date,outcome,pts_scored,pts_s
 	 ('OKC','CHI','2023-11-22','W',116,102,14,18,0,139,119.3,'0','0','logos/okc.png','logos/chi.png','OKC','Vs.'),
 	 ('ATL','BKN','2023-11-22','W',147,145,2,15,5,152,124.1,'2','1','logos/atl.png','logos/bkn.png','ATL','Vs.'),
 	 ('NOP','SAC','2023-11-22','W',117,112,5,17,9,131,113.5,'0','0','logos/nop.png','logos/sac.png','NOP','Vs.');
+
+-- Playoff series context (state AFTER each game). NULL outside the postseason.
+UPDATE recent_games_teams
+SET series_round = 'NBA Finals', series_status = 'MIA leads 2-0', series_game_number = 2
+WHERE team = 'MIA' AND opponent = 'CLE';
+UPDATE recent_games_teams
+SET series_round = 'Conf. Finals', series_status = 'Series tied 1-1', series_game_number = 2
+WHERE team = 'BOS' AND opponent = 'MIL';
+UPDATE recent_games_teams
+SET series_round = 'First Round', series_status = 'OKC leads 3-1', series_game_number = 4
+WHERE team = 'OKC' AND opponent = 'CHI';
 
 
 DROP TABLE IF EXISTS team_adv_stats;

--- a/src/pages/recent_games.py
+++ b/src/pages/recent_games.py
@@ -12,6 +12,7 @@ import dash_bootstrap_components as dbc
 
 from src.data_access.cache import get_table
 from src.recent_games_helpers import build_game_card_specs, pbp_flow_stats
+from src.shell import playoffs_enabled
 from src.theme.plotly import TRACE_HOVERLABEL, apply_dark_layout
 from src.ui.tables import dark_datatable
 from src.utils import pbp_transformer
@@ -222,12 +223,19 @@ def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]
     home_chip_style = {"backgroundColor": home_bg} if home_bg else None
     away_chip_style = {"backgroundColor": away_bg} if away_bg else None
     result_line, result_meta = _result_line(game_desc, home_abbr, away_abbr)
+    spec = next((s for s in _game_card_specs() if s.game_description == game_desc), None)
+    series_line = (
+        _series_chip(spec.series_round, spec.series_status, playoffs_enabled())
+        if spec is not None
+        else ""
+    )
 
     legend = html.Div(
         [
             html.Div(
                 [
                     html.Span(title_line, className="recent-games-pbp-heading-matchup"),
+                    series_line,
                     result_line,
                 ],
                 className="recent-games-pbp-heading-titles",
@@ -286,10 +294,28 @@ def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]
     }
 
 
+def _series_chip(
+    series_round: str | None, series_status: str | None, playoffs_active: bool
+) -> html.Div | str:
+    """Playoff series pill, e.g. 'NBA Finals · MIA leads 2-0'.
+
+    Gated on the ``playoffs`` feature flag (authoritative) plus row-level series data,
+    so a stale series_status in a mart can't surface during the regular season.
+    """
+    if not playoffs_active or not series_status:
+        return ""
+    bits = [series_round, series_status] if series_round else [series_status]
+    return html.Div(
+        " · ".join(bits),
+        className="recent-games-card-series",
+    )
+
+
 def render_game_cards(selected: str | None) -> html.Div:
     game_card_specs = _game_card_specs()
     if not game_card_specs:
         return html.Div("No games in PBP feed.", className="text-muted small")
+    playoffs_active = playoffs_enabled()
     n = len(game_card_specs)
     row_cls = "recent-games-card-row recent-games-card-row--scroll"
     if n <= 8:
@@ -309,6 +335,7 @@ def render_game_cards(selected: str | None) -> html.Div:
                         ),
                         className="recent-games-card-top",
                     ),
+                    _series_chip(spec.series_round, spec.series_status, playoffs_active),
                     html.Div(
                         [
                             html.Div(

--- a/src/pages/schedule.py
+++ b/src/pages/schedule.py
@@ -11,6 +11,7 @@ from src.config import SINGLE_BAR_COLOR
 from src.table_columns.future_schedule import future_schedule_columns
 from src.data_access.cache import get_table
 from src.theme.plotly import TRACE_HOVERLABEL, apply_dark_layout
+from src.shell import playoffs_enabled
 from src.ui.sections import page_hero, section_header
 from src.ui.tables import dark_datatable
 
@@ -27,6 +28,15 @@ SCHEDULE_PLOT_OPTIONS = [
     {"label": "Covering the Spread Metrics", "value": "team-spread-metrics"},
     {"label": "Game Types by Margin of Victory", "value": "game-types"},
 ]
+
+
+def _clean_text(val: Any) -> str:
+    """Normalize an optional cell to display text ('' when missing). Whole floats -> ints."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return ""
+    if isinstance(val, float) and val.is_integer():
+        return str(int(val))
+    return str(val).strip()
 
 
 def _truthy_great_value(raw: object) -> bool:
@@ -66,6 +76,31 @@ def _fmt_rank(val: Any) -> str:
         return "-"
 
 
+def _series_line(
+    series_round: Any, series_game_number: Any, series_status: Any, playoffs_active: bool
+) -> html.Div | str:
+    """Playoff series strip for a tonight card, e.g. 'NBA Finals · Game 3 · Series tied 1-1'.
+
+    Gated on the ``playoffs`` feature flag (authoritative) plus row-level series data, so a
+    stale series_* value in the mart can't surface during the regular season.
+    """
+    if not playoffs_active:
+        return ""
+    round_txt = _clean_text(series_round)
+    status_txt = _clean_text(series_status)
+    game_no = _clean_text(series_game_number)
+    if not round_txt and not status_txt:
+        return ""
+    bits: list[str] = []
+    if round_txt:
+        bits.append(round_txt)
+    if game_no:
+        bits.append(f"Game {game_no}")
+    if status_txt:
+        bits.append(status_txt)
+    return html.Div(" · ".join(bits), className="schedule-card-series")
+
+
 def create_tonight_games_cards() -> html.Div:
     """Tonight slate as responsive matchup cards (same fields as former DataTable)."""
     df = get_table("schedule_tonights_games")
@@ -75,6 +110,7 @@ def create_tonight_games_cards() -> html.Div:
             className="schedule-empty text-muted small",
         )
 
+    playoffs_active = playoffs_enabled()
     slate_date_label: str | None = None
     if "game_date" in df.columns:
         parsed = pd.to_datetime(df["game_date"], errors="coerce").dropna()
@@ -108,6 +144,12 @@ def create_tonight_games_cards() -> html.Div:
                     html.Div(
                         meta_children,
                         className=meta_cls,
+                    ),
+                    _series_line(
+                        row.get("series_round"),
+                        row.get("series_game_number"),
+                        row.get("series_status"),
+                        playoffs_active,
                     ),
                     html.Div(
                         [

--- a/src/recent_games_helpers.py
+++ b/src/recent_games_helpers.py
@@ -18,6 +18,26 @@ class GameCardSpec:
     margin: int
     away_logo: str
     home_logo: str
+    series_round: str | None = None
+    series_status: str | None = None
+    series_game_number: int | None = None
+
+
+def _clean_str(raw: Any) -> str | None:
+    """Normalize an optional text cell to a non-empty string, else None."""
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def _clean_int(raw: Any) -> int | None:
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
+        return None
+    try:
+        return int(float(raw))
+    except TypeError, ValueError:
+        return None
 
 
 def _teams_row_for_matchup(teams_df: pd.DataFrame, home: str, away: str) -> pd.Series | None:
@@ -56,8 +76,14 @@ def build_game_card_specs(pbp_df: pd.DataFrame, teams_df: pd.DataFrame) -> list[
         margin = abs(home_pts - away_pts)
         away_logo = f"logos/{away.lower()}.png"
         home_logo = f"logos/{home.lower()}.png"
+        series_round = None
+        series_status = None
+        series_game_number = None
         tr = _teams_row_for_matchup(teams_df, home, away)
         if tr is not None:
+            series_round = _clean_str(tr.get("series_round"))
+            series_status = _clean_str(tr.get("series_status"))
+            series_game_number = _clean_int(tr.get("series_game_number"))
             margin = abs(int(tr["mov"]))
             hteam = str(tr["home_team"])
             win = str(tr["team"])
@@ -79,6 +105,9 @@ def build_game_card_specs(pbp_df: pd.DataFrame, teams_df: pd.DataFrame) -> list[
                 margin=margin,
                 away_logo=away_logo,
                 home_logo=home_logo,
+                series_round=series_round,
+                series_status=series_status,
+                series_game_number=series_game_number,
             )
         )
     return out

--- a/src/server.py
+++ b/src/server.py
@@ -53,7 +53,7 @@ def _process_rss_bytes() -> int | None:
         statm = PROC_STATM_PATH.read_text().split()
         resident_pages = int(statm[1])
         page_size = os.sysconf("SC_PAGE_SIZE")
-    except (OSError, IndexError, ValueError):
+    except OSError, IndexError, ValueError:
         return None
     return resident_pages * page_size
 

--- a/src/shell.py
+++ b/src/shell.py
@@ -3,24 +3,38 @@ from __future__ import annotations
 import pandas as pd
 
 
+def feature_flag_enabled(feature_flags_df: pd.DataFrame | None, flag: str) -> bool:
+    """True when ``flag`` is present and enabled in the feature_flags table."""
+    if feature_flags_df is None or feature_flags_df.empty:
+        return False
+    flags = feature_flags_df.set_index("flag")["is_enabled"].to_dict()
+    v = flags.get(flag)
+    if v is None or pd.isna(v):
+        return False
+    try:
+        return int(v) == 1
+    except TypeError, ValueError:
+        return bool(v)
+
+
+def playoffs_enabled() -> bool:
+    """Authoritative 'are we in the postseason' switch, read from feature_flags."""
+    # Lazy import keeps the cache layer out of shell's import graph.
+    from src.data_access.cache import get_table
+
+    try:
+        feature_flags_df = get_table("feature_flags")
+    except KeyError:
+        return False
+    return feature_flag_enabled(feature_flags_df, "playoffs")
+
+
 def season_phase_label(feature_flags_df: pd.DataFrame) -> str:
     if feature_flags_df is None or feature_flags_df.empty:
         return "NBA"
-
-    flags = feature_flags_df.set_index("flag")["is_enabled"].to_dict()
-
-    def _on(name: str) -> bool:
-        v = flags.get(name)
-        if v is None or pd.isna(v):
-            return False
-        try:
-            return int(v) == 1
-        except TypeError, ValueError:
-            return bool(v)
-
-    if _on("playoffs"):
+    if feature_flag_enabled(feature_flags_df, "playoffs"):
         return "Playoffs"
-    if _on("season"):
+    if feature_flag_enabled(feature_flags_df, "season"):
         return "Regular season"
     return "NBA"
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -653,6 +653,19 @@ img[src*="/nba"] {
   font-variant-numeric: tabular-nums;
 }
 
+.schedule-card-series {
+  margin-top: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-header);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-accent);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
 .schedule-card-matchup {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -1182,6 +1195,27 @@ img[src*="/nba"] {
   font-size: 0.75rem;
   color: var(--text-muted);
   text-align: center;
+}
+
+.recent-games-card-series {
+  margin: 2px auto 8px;
+  padding: 2px 10px;
+  max-width: 100%;
+  border-radius: 999px;
+  background: var(--surface-header);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-accent);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.recent-games-pbp-heading-titles .recent-games-card-series {
+  font-size: 0.78rem;
 }
 
 .recent-games-flow-eyebrow {

--- a/tests/unit/test_recent_games_helpers.py
+++ b/tests/unit/test_recent_games_helpers.py
@@ -96,6 +96,67 @@ def test_build_game_card_specs_tie_score_uses_away_as_winner_abbr_when_no_winner
     assert specs[0].margin == 2
 
 
+def test_build_game_card_specs_carries_series_fields():
+    pbp = pd.DataFrame(
+        {
+            "game_description": ["G1"],
+            "home_team": ["H"],
+            "away_team": ["V"],
+            "score_home": [110],
+            "score_away": [104],
+            "winning_team": ["H"],
+        }
+    )
+    teams = pd.DataFrame(
+        [
+            {
+                "team": "H",
+                "opponent": "V",
+                "mov": 6,
+                "home_team": "H",
+                "team_logo": "logos/h.png",
+                "opp_logo": "logos/v.png",
+                "series_round": "NBA Finals",
+                "series_status": "H leads 2-0",
+                "series_game_number": 2.0,
+            }
+        ]
+    )
+    spec = build_game_card_specs(pbp, teams)[0]
+    assert spec.series_round == "NBA Finals"
+    assert spec.series_status == "H leads 2-0"
+    assert spec.series_game_number == 2  # coerced to int
+
+
+def test_build_game_card_specs_series_fields_default_none_without_columns():
+    pbp = pd.DataFrame(
+        {
+            "game_description": ["G1"],
+            "home_team": ["H"],
+            "away_team": ["V"],
+            "score_home": [100],
+            "score_away": [90],
+            "winning_team": ["H"],
+        }
+    )
+    teams = pd.DataFrame(
+        [
+            {
+                "team": "H",
+                "opponent": "V",
+                "mov": 10,
+                "home_team": "H",
+                "team_logo": "logos/h.png",
+                "opp_logo": "logos/v.png",
+            }
+        ]
+    )
+    spec = build_game_card_specs(pbp, teams)[0]
+    assert spec.series_round is None
+    assert spec.series_status is None
+    assert spec.series_game_number is None
+
+
 def test_teams_row_no_match_falls_back_to_score_margin():
     pbp = pd.DataFrame(
         {

--- a/tests/unit/test_recent_games_page_helpers.py
+++ b/tests/unit/test_recent_games_page_helpers.py
@@ -11,6 +11,7 @@ from src.pages.recent_games import (
     _flow_legend_and_stats,
     _pbp_chart_subtitle,
     _pbp_stat_tile,
+    _series_chip,
     _slate_date_label,
     _slate_summary_bar,
 )
@@ -73,6 +74,30 @@ def test_pbp_stat_tile_renders():
     assert "Lead changes" in s
     assert "49" in s
     assert "recent-games-pbp-stat-tile" in s
+
+
+def test_series_chip_shown_when_playoffs_active():
+    chip = _series_chip("NBA Finals", "MIA leads 2-0", playoffs_active=True)
+    assert isinstance(chip, html.Div)
+    flat = str(chip)
+    assert "NBA Finals" in flat
+    assert "MIA leads 2-0" in flat
+    assert "recent-games-card-series" in flat
+
+
+def test_series_chip_hidden_when_flag_off_even_with_data():
+    # Authoritative gate: stale series data must not leak in the regular season.
+    assert _series_chip("NBA Finals", "MIA leads 2-0", playoffs_active=False) == ""
+
+
+def test_series_chip_hidden_when_no_series_status():
+    assert _series_chip("NBA Finals", None, playoffs_active=True) == ""
+    assert _series_chip(None, "", playoffs_active=True) == ""
+
+
+def test_series_chip_status_only_no_round():
+    chip = _series_chip(None, "MIA leads 2-0", playoffs_active=True)
+    assert chip.children == "MIA leads 2-0"
 
 
 def test_flow_legend_and_stats_missing_game():

--- a/tests/unit/test_schedule_page_helpers.py
+++ b/tests/unit/test_schedule_page_helpers.py
@@ -34,6 +34,66 @@ def test_fmt_rank():
     assert schedule_mod._fmt_rank(None) == "-"
 
 
+def test_clean_text_cases():
+    assert schedule_mod._clean_text("NBA Finals") == "NBA Finals"
+    assert schedule_mod._clean_text(3.0) == "3"  # whole float -> int
+    assert schedule_mod._clean_text(3) == "3"
+    assert schedule_mod._clean_text(None) == ""
+    assert schedule_mod._clean_text(float("nan")) == ""
+
+
+def test_series_line_shown_when_playoffs_active():
+    line = schedule_mod._series_line("NBA Finals", 3, "Series tied 1-1", playoffs_active=True)
+    flat = str(line)
+    assert "NBA Finals" in flat
+    assert "Game 3" in flat
+    assert "Series tied 1-1" in flat
+    assert "schedule-card-series" in flat
+
+
+def test_series_line_hidden_when_flag_off_even_with_data():
+    assert (
+        schedule_mod._series_line("NBA Finals", 3, "Series tied 1-1", playoffs_active=False) == ""
+    )
+
+
+def test_series_line_hidden_when_no_series_data():
+    assert schedule_mod._series_line(None, None, None, playoffs_active=True) == ""
+
+
+def test_create_tonight_games_cards_series_gated_by_flag():
+    row = {
+        "home_team": "Atlanta Hawks",
+        "away_team": "New York Knicks",
+        "avg_team_rank": 10,
+        "home_team_odds": "Atlanta Hawks (-125)",
+        "away_team_odds": "New York Knicks (+105)",
+        "start_time": "7:30 PM",
+        "game_date": pd.Timestamp("2024-05-20"),
+        "home_moneyline": -125.0,
+        "away_moneyline": 105.0,
+        "home_team_predicted_win_pct": 0.531,
+        "away_team_predicted_win_pct": 0.469,
+        "home_is_great_value": 0,
+        "away_is_great_value": 0,
+        "series_round": "NBA Finals",
+        "series_status": "Series tied 1-1",
+        "series_game_number": 3,
+    }
+    df = pd.DataFrame([row])
+
+    with patch.object(schedule_mod, "get_table", return_value=df):
+        with patch.object(schedule_mod, "playoffs_enabled", return_value=True):
+            shown = str(schedule_mod.create_tonight_games_cards())
+        with patch.object(schedule_mod, "playoffs_enabled", return_value=False):
+            hidden = str(schedule_mod.create_tonight_games_cards())
+
+    assert "schedule-card-series" in shown
+    assert "Series tied 1-1" in shown
+    assert "schedule-card-series" not in hidden
+    assert "Series tied 1-1" not in hidden
+
+
 def test_create_tonight_games_cards_empty_slate():
     empty = pd.DataFrame(
         columns=[

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -1,6 +1,56 @@
 import pandas as pd
 
-from src.shell import season_phase_label, tab_label_with_badge
+from src.shell import (
+    feature_flag_enabled,
+    playoffs_enabled,
+    season_phase_label,
+    tab_label_with_badge,
+)
+
+
+def _flags(playoffs: object) -> pd.DataFrame:
+    return pd.DataFrame({"flag": ["season", "playoffs"], "is_enabled": [1, playoffs]})
+
+
+def test_feature_flag_enabled_on():
+    assert feature_flag_enabled(_flags(1), "playoffs") is True
+
+
+def test_feature_flag_enabled_off():
+    assert feature_flag_enabled(_flags(0), "playoffs") is False
+
+
+def test_feature_flag_enabled_missing_flag():
+    assert feature_flag_enabled(_flags(1), "nope") is False
+
+
+def test_feature_flag_enabled_none_and_empty():
+    assert feature_flag_enabled(None, "playoffs") is False
+    assert feature_flag_enabled(pd.DataFrame(), "playoffs") is False
+
+
+def test_feature_flag_enabled_na_value():
+    assert feature_flag_enabled(_flags(pd.NA), "playoffs") is False
+
+
+def test_feature_flag_enabled_non_integer_uses_bool_coercion():
+    assert feature_flag_enabled(_flags("x"), "playoffs") is True
+
+
+def test_playoffs_enabled_reads_feature_flags(monkeypatch):
+    monkeypatch.setattr("src.data_access.cache.get_table", lambda name: _flags(1), raising=True)
+    assert playoffs_enabled() is True
+
+    monkeypatch.setattr("src.data_access.cache.get_table", lambda name: _flags(0), raising=True)
+    assert playoffs_enabled() is False
+
+
+def test_playoffs_enabled_missing_table_is_false(monkeypatch):
+    def _raise(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr("src.data_access.cache.get_table", _raise, raising=True)
+    assert playoffs_enabled() is False
 
 
 def test_season_phase_playoffs():


### PR DESCRIPTION
### Description
Surfaces playoff series context (e.g. "NBA Finals · MIA leads 2-0") on the Recent Games and Schedule tabs, gated on the `playoffs` feature flag so it stays hidden during the regular season.

## Added
- Series chip on Recent Games cards + PBP heading, and a series line on tonight's Schedule cards.
- `feature_flag_enabled` / `playoffs_enabled` helpers in shell as the authoritative postseason gate.
- Unit tests for the flag helpers, gated rendering, and series fields on `GameCardSpec`.

## Updated
- `recent_games_teams`, `schedule_tonights_games`, and `schedule_season_remaining` now carry series columns (bootstrap SQL + demo data).
- `GameCardSpec` carries series round/status/game number.