### PR TITLE
feat: tighten recent games page and extract server routes

### DIFF
--- a/src/data_access/__init__.py
+++ b/src/data_access/__init__.py
@@ -1,1 +1,0 @@
-"""Data access helpers for dashboard table loading and refresh."""

--- a/src/pages/recent_games.py
+++ b/src/pages/recent_games.py
@@ -59,9 +59,9 @@ def _game_options() -> tuple[list[dict], str | None]:
 def _slate_date_label() -> str:
     pbp_df = get_table("pbp")
     if pbp_df is None or pbp_df.empty or "game_date" not in pbp_df.columns:
-        return datetime.now().strftime("%a, %b %d, %Y")
+        return datetime.now().strftime("%A, %b %d, %Y")
     d = pd.Timestamp(pbp_df["game_date"].max())
-    return d.strftime("%a, %b %d, %Y")
+    return d.strftime("%A, %b %d, %Y")
 
 
 def _pbp_chart_subtitle() -> str:
@@ -85,7 +85,7 @@ def _slate_summary_bar() -> html.Div:
             ],
             className="recent-games-slate-bar-inner",
         ),
-        className="recent-games-slate-bar mb-3",
+        className="recent-games-slate-bar mb-2",
     )
 
 
@@ -136,43 +136,12 @@ def _fmt_lead_pct(raw: object) -> str:
         return "-"
 
 
-def _result_line(game_desc: str, home_abbr: str, away_abbr: str) -> tuple[html.Div | str, dict]:
-    spec = next((s for s in _game_card_specs() if s.game_description == game_desc), None)
-    if spec is None:
-        return "", {}
-
-    away_win = spec.winner_abbr == away_abbr
-    home_win = spec.winner_abbr == home_abbr
-    winner_abbr = spec.winner_abbr or (home_abbr if spec.home_pts > spec.away_pts else away_abbr)
-    final_tag = "Final"
-
-    result = html.Div(
-        [
-            html.Span(
-                f"{away_abbr} {spec.away_pts}",
-                className="recent-games-pbp-result-team"
-                + (" recent-games-pbp-result-team--win" if away_win else ""),
-            ),
-            html.Span(",", className="recent-games-pbp-result-sep"),
-            html.Span(
-                f"{home_abbr} {spec.home_pts}",
-                className="recent-games-pbp-result-team"
-                + (" recent-games-pbp-result-team--win" if home_win else ""),
-            ),
-            html.Span(f"· {final_tag}", className="recent-games-pbp-result-meta"),
-        ],
-        className="recent-games-pbp-result-line",
-    )
-    return result, {
-        "winner": winner_abbr,
-        "away_pts": spec.away_pts,
-        "home_pts": spec.home_pts,
-        "final_tag": final_tag,
-    }
-
-
 def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]:
-    """Centered heading above the margin chart: away @ home title, chart legend, inline stats."""
+    """Centered heading above the margin chart: away @ home title, chart legend, inline stats.
+
+    Matchup name aside, the score and playoff-series chip live in the game card above the
+    chart, so they are intentionally omitted here to avoid duplicating the same facts twice.
+    """
     pbp_df, pbp_plot_kpis, pbp_plot_df = _pbp_data()
     if not game_desc or pbp_df is None or pbp_df.empty:
         return "", {}
@@ -222,22 +191,11 @@ def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]
     away_bg = _hex_tint_rgba(away_hex)
     home_chip_style = {"backgroundColor": home_bg} if home_bg else None
     away_chip_style = {"backgroundColor": away_bg} if away_bg else None
-    result_line, result_meta = _result_line(game_desc, home_abbr, away_abbr)
-    spec = next((s for s in _game_card_specs() if s.game_description == game_desc), None)
-    series_line = (
-        _series_chip(spec.series_round, spec.series_status, playoffs_enabled())
-        if spec is not None
-        else ""
-    )
 
     legend = html.Div(
         [
             html.Div(
-                [
-                    html.Span(title_line, className="recent-games-pbp-heading-matchup"),
-                    series_line,
-                    result_line,
-                ],
+                html.Span(title_line, className="recent-games-pbp-heading-matchup"),
                 className="recent-games-pbp-heading-titles",
             ),
             html.Div(
@@ -289,7 +247,6 @@ def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]
         "home_pct_leading": home_lead_pct,
         "away_pct_leading": away_lead_pct,
         "tie_pct": tie_pct,
-        **result_meta,
         **st,
     }
 
@@ -544,11 +501,11 @@ def recent_games_layout() -> html.Div:
                     [
                         html.H1(
                             f"Recent Games on {_slate_date_label()}",
-                            className="recent-games-hero-title recent-games-hero-compact mb-2",
+                            className="recent-games-hero-title recent-games-hero-compact mb-1",
                         ),
                         html.P(
                             _pbp_chart_subtitle(),
-                            className="text-muted small mb-2",
+                            className="text-muted small mb-1",
                         ),
                         _slate_summary_bar(),
                         html.Div(
@@ -564,10 +521,10 @@ def recent_games_layout() -> html.Div:
                         html.Div(
                             id="recent-games-card-strip",
                             children=render_game_cards(default_sel),
-                            className="recent-games-card-strip mb-3 w-100",
+                            className="recent-games-card-strip mb-2 w-100",
                         ),
                     ],
-                    className="recent-games-shell text-center w-100 py-3",
+                    className="recent-games-shell text-center w-100 py-2",
                 ),
                 html.Div(
                     [
@@ -578,8 +535,12 @@ def recent_games_layout() -> html.Div:
                                     [
                                         dcc.Graph(
                                             id="pbp-analysis-plot",
-                                            config={"displayModeBar": False},
-                                            style={"height": "560px", "width": "100%"},
+                                            config={"displayModeBar": False, "responsive": True},
+                                            style={
+                                                "height": "min(560px, calc(100vh - 320px))",
+                                                "minHeight": "380px",
+                                                "width": "100%",
+                                            },
                                         ),
                                     ],
                                     width=12,

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,0 +1,129 @@
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+
+from src.data_access.cache import get_snapshot_metadata, has_snapshot
+from src.data_access.cache import refresh_data as refresh_dashboard_data
+
+PROC_STATM_PATH = Path("/proc/self/statm")
+CGROUP_V2_MEMORY_CURRENT_PATH = Path("/sys/fs/cgroup/memory.current")
+CGROUP_V2_MEMORY_MAX_PATH = Path("/sys/fs/cgroup/memory.max")
+CGROUP_V1_MEMORY_CURRENT_PATH = Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+CGROUP_V1_MEMORY_LIMIT_PATH = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+
+def _bytes_to_mb(value: int | None) -> float | None:
+    if value is None:
+        return None
+    return round(value / 1024 / 1024, 1)
+
+
+def _read_int_file(path: Path) -> int | None:
+    try:
+        value = path.read_text().strip()
+    except OSError:
+        return None
+    if not value or value == "max":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _process_rss_bytes() -> int | None:
+    try:
+        statm = PROC_STATM_PATH.read_text().split()
+        resident_pages = int(statm[1])
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except OSError, IndexError, ValueError:
+        return None
+    return resident_pages * page_size
+
+
+def _container_memory_bytes() -> tuple[int | None, int | None]:
+    current = _read_int_file(CGROUP_V2_MEMORY_CURRENT_PATH)
+    limit = _read_int_file(CGROUP_V2_MEMORY_MAX_PATH)
+    if current is not None or limit is not None:
+        return current, limit
+
+    return (
+        _read_int_file(CGROUP_V1_MEMORY_CURRENT_PATH),
+        _read_int_file(CGROUP_V1_MEMORY_LIMIT_PATH),
+    )
+
+
+def _memory_metadata() -> dict[str, float | None]:
+    container_current, container_limit = _container_memory_bytes()
+    return {
+        "process_rss_mb": _bytes_to_mb(_process_rss_bytes()),
+        "container_current_mb": _bytes_to_mb(container_current),
+        "container_limit_mb": _bytes_to_mb(container_limit),
+    }
+
+
+def _validate_internal_token():
+    expected_token = os.environ.get("DATA_REFRESH_TOKEN")
+    provided_token = request.headers.get("X-Refresh-Token")
+
+    if not expected_token:
+        return jsonify({"error": "DATA_REFRESH_TOKEN is not configured"}), 500
+
+    if provided_token != expected_token:
+        return jsonify({"error": "unauthorized"}), 401
+
+    return None
+
+
+def register_routes(server: Flask) -> None:
+    """Attach the internal ops endpoints and data-load hook to the Flask server."""
+
+    @server.post("/internal/refresh-data")
+    def refresh_data_endpoint():
+        token_error = _validate_internal_token()
+        if token_error is not None:
+            return token_error
+
+        result = refresh_dashboard_data()
+        return jsonify(
+            {
+                "status": "ok",
+                "refreshed_at": result.refreshed_at.isoformat(),
+                "duration_seconds": result.duration_seconds,
+                "row_counts": result.row_counts,
+            }
+        )
+
+    @server.get("/internal/health")
+    def health_endpoint():
+        token_error = _validate_internal_token()
+        if token_error is not None:
+            return token_error
+
+        metadata = get_snapshot_metadata()
+        snapshot_ready = has_snapshot()
+        last_refreshed_at = metadata["last_refreshed_at"]
+        return (
+            jsonify(
+                {
+                    "status": "ok" if snapshot_ready else "unavailable",
+                    "has_snapshot": snapshot_ready,
+                    "last_refreshed_at": (
+                        last_refreshed_at.isoformat() if last_refreshed_at is not None else None
+                    ),
+                    "duration_seconds": metadata["duration_seconds"],
+                    "row_counts": metadata["row_counts"],
+                    "memory": _memory_metadata(),
+                }
+            ),
+            200 if snapshot_ready else 503,
+        )
+
+    @server.before_request
+    def ensure_dashboard_data_loaded():
+        if request.path.startswith("/internal/"):
+            return None
+        if not has_snapshot():
+            refresh_dashboard_data()
+        return None

--- a/src/server.py
+++ b/src/server.py
@@ -1,10 +1,9 @@
 import os
-from pathlib import Path
 
 import dash
 import dash_bootstrap_components as dbc
 from dash import Input, Output, html
-from flask import has_request_context, jsonify, request
+from flask import has_request_context, request
 
 from src.pages.about import about_layout
 from src.pages.overview import overview_layout
@@ -16,67 +15,12 @@ from src.pages.social_media_analysis import social_media_analysis_layout
 from src.pages.team_analysis import team_analysis_layout
 
 from src.data_access.cache import get_table
-from src.data_access.cache import get_snapshot_metadata
 from src.data_access.cache import has_snapshot
 from src.data_access.cache import refresh_data as refresh_dashboard_data
+from src.routes import register_routes
 from src.shell import tab_label_with_badge
 
 APP_TITLE = "NBA Dashboard"
-PROC_STATM_PATH = Path("/proc/self/statm")
-CGROUP_V2_MEMORY_CURRENT_PATH = Path("/sys/fs/cgroup/memory.current")
-CGROUP_V2_MEMORY_MAX_PATH = Path("/sys/fs/cgroup/memory.max")
-CGROUP_V1_MEMORY_CURRENT_PATH = Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
-CGROUP_V1_MEMORY_LIMIT_PATH = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
-
-
-def _bytes_to_mb(value: int | None) -> float | None:
-    if value is None:
-        return None
-    return round(value / 1024 / 1024, 1)
-
-
-def _read_int_file(path: Path) -> int | None:
-    try:
-        value = path.read_text().strip()
-    except OSError:
-        return None
-    if not value or value == "max":
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
-def _process_rss_bytes() -> int | None:
-    try:
-        statm = PROC_STATM_PATH.read_text().split()
-        resident_pages = int(statm[1])
-        page_size = os.sysconf("SC_PAGE_SIZE")
-    except OSError, IndexError, ValueError:
-        return None
-    return resident_pages * page_size
-
-
-def _container_memory_bytes() -> tuple[int | None, int | None]:
-    current = _read_int_file(CGROUP_V2_MEMORY_CURRENT_PATH)
-    limit = _read_int_file(CGROUP_V2_MEMORY_MAX_PATH)
-    if current is not None or limit is not None:
-        return current, limit
-
-    return (
-        _read_int_file(CGROUP_V1_MEMORY_CURRENT_PATH),
-        _read_int_file(CGROUP_V1_MEMORY_LIMIT_PATH),
-    )
-
-
-def _memory_metadata() -> dict[str, float | None]:
-    container_current, container_limit = _container_memory_bytes()
-    return {
-        "process_rss_mb": _bytes_to_mb(_process_rss_bytes()),
-        "container_current_mb": _bytes_to_mb(container_current),
-        "container_limit_mb": _bytes_to_mb(container_limit),
-    }
 
 
 def _recent_games_count() -> int | None:
@@ -104,70 +48,7 @@ app = dash.Dash(
     title=APP_TITLE,
 )
 
-
-def _validate_internal_token():
-    expected_token = os.environ.get("DATA_REFRESH_TOKEN")
-    provided_token = request.headers.get("X-Refresh-Token")
-
-    if not expected_token:
-        return jsonify({"error": "DATA_REFRESH_TOKEN is not configured"}), 500
-
-    if provided_token != expected_token:
-        return jsonify({"error": "unauthorized"}), 401
-
-    return None
-
-
-@app.server.post("/internal/refresh-data")
-def refresh_data_endpoint():
-    token_error = _validate_internal_token()
-    if token_error is not None:
-        return token_error
-
-    result = refresh_dashboard_data()
-    return jsonify(
-        {
-            "status": "ok",
-            "refreshed_at": result.refreshed_at.isoformat(),
-            "duration_seconds": result.duration_seconds,
-            "row_counts": result.row_counts,
-        }
-    )
-
-
-@app.server.get("/internal/health")
-def health_endpoint():
-    token_error = _validate_internal_token()
-    if token_error is not None:
-        return token_error
-
-    metadata = get_snapshot_metadata()
-    snapshot_ready = has_snapshot()
-    last_refreshed_at = metadata["last_refreshed_at"]
-    return (
-        jsonify(
-            {
-                "status": "ok" if snapshot_ready else "unavailable",
-                "has_snapshot": snapshot_ready,
-                "last_refreshed_at": (
-                    last_refreshed_at.isoformat() if last_refreshed_at is not None else None
-                ),
-                "duration_seconds": metadata["duration_seconds"],
-                "row_counts": metadata["row_counts"],
-                "memory": _memory_metadata(),
-            }
-        ),
-        200 if snapshot_ready else 503,
-    )
-
-
-@app.server.before_request
-def ensure_dashboard_data_loaded():
-    if request.path.startswith("/internal/"):
-        return None
-    if not has_snapshot():
-        refresh_dashboard_data()
-    return None
+register_routes(app.server)
 
 
 def _tabs() -> dbc.Tabs:

--- a/src/social_media_insights.py
+++ b/src/social_media_insights.py
@@ -1,5 +1,3 @@
-"""Aggregations for the Social Media Analysis page (no DB changes; derived in-app)."""
-
 from __future__ import annotations
 
 from typing import Any

--- a/src/social_media_plots.py
+++ b/src/social_media_plots.py
@@ -1,5 +1,3 @@
-"""Plotly figures for social media pages (no database import)."""
-
 from __future__ import annotations
 
 import numpy as np

--- a/src/table_columns/__init__.py
+++ b/src/table_columns/__init__.py
@@ -1,1 +1,0 @@
-"""Dash DataTable column definitions."""

--- a/src/team_analysis_panels.py
+++ b/src/team_analysis_panels.py
@@ -1,5 +1,3 @@
-"""Custom HTML panels for Team Analysis (injuries + transactions)."""
-
 from __future__ import annotations
 
 import re

--- a/static/styles.css
+++ b/static/styles.css
@@ -874,7 +874,7 @@ img[src*="/nba"] {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .recent-games-pbp-heading-matchup {
@@ -882,30 +882,6 @@ img[src*="/nba"] {
   font-size: clamp(1.1rem, 2.2vw, 1.55rem);
   font-weight: 600;
   color: var(--text);
-}
-
-.recent-games-pbp-result-line {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0 6px;
-  font-size: 0.92rem;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.recent-games-pbp-result-team {
-  font-weight: 600;
-}
-
-.recent-games-pbp-result-team--win {
-  color: var(--text-accent);
-}
-
-.recent-games-pbp-result-sep,
-.recent-games-pbp-result-meta {
-  color: var(--text-muted);
 }
 
 .recent-games-pbp-heading-row {
@@ -1212,10 +1188,6 @@ img[src*="/nba"] {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.recent-games-pbp-heading-titles .recent-games-card-series {
-  font-size: 0.78rem;
 }
 
 .recent-games-flow-eyebrow {

--- a/tests/integration/test_server_app.py
+++ b/tests/integration/test_server_app.py
@@ -5,6 +5,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import html
 
+import src.routes as routes
 import src.server as srv
 from src.data_access.cache import RefreshResult
 
@@ -58,7 +59,7 @@ def test_refresh_data_endpoint_requires_configured_token(monkeypatch):
 
 def test_refresh_data_endpoint_rejects_bad_token(monkeypatch):
     monkeypatch.setenv("DATA_REFRESH_TOKEN", "secret")
-    with mock.patch.object(srv, "refresh_dashboard_data") as refresh_mock:
+    with mock.patch.object(routes, "refresh_dashboard_data") as refresh_mock:
         response = srv.app.server.test_client().post(
             "/internal/refresh-data",
             headers={"X-Refresh-Token": "wrong"},
@@ -76,7 +77,7 @@ def test_refresh_data_endpoint_refreshes_with_valid_token(monkeypatch):
         duration_seconds=1.25,
         row_counts={"standings": 30},
     )
-    with mock.patch.object(srv, "refresh_dashboard_data", return_value=result) as refresh_mock:
+    with mock.patch.object(routes, "refresh_dashboard_data", return_value=result) as refresh_mock:
         response = srv.app.server.test_client().post(
             "/internal/refresh-data",
             headers={"X-Refresh-Token": "secret"},
@@ -120,10 +121,10 @@ def test_health_endpoint_returns_snapshot_metadata(monkeypatch):
     }
 
     with (
-        mock.patch.object(srv, "has_snapshot", return_value=True),
-        mock.patch.object(srv, "get_snapshot_metadata", return_value=metadata),
+        mock.patch.object(routes, "has_snapshot", return_value=True),
+        mock.patch.object(routes, "get_snapshot_metadata", return_value=metadata),
         mock.patch.object(
-            srv,
+            routes,
             "_memory_metadata",
             return_value={
                 "process_rss_mb": 355.4,
@@ -161,10 +162,10 @@ def test_health_endpoint_reports_unavailable_without_snapshot(monkeypatch):
     }
 
     with (
-        mock.patch.object(srv, "has_snapshot", return_value=False),
-        mock.patch.object(srv, "get_snapshot_metadata", return_value=metadata),
+        mock.patch.object(routes, "has_snapshot", return_value=False),
+        mock.patch.object(routes, "get_snapshot_metadata", return_value=metadata),
         mock.patch.object(
-            srv,
+            routes,
             "_memory_metadata",
             return_value={
                 "process_rss_mb": None,
@@ -201,12 +202,12 @@ def test_memory_metadata_reads_process_and_cgroup_values(monkeypatch, tmp_path):
     memory_current.write_text(str(128 * 1024 * 1024))
     memory_max.write_text(str(512 * 1024 * 1024))
 
-    monkeypatch.setattr(srv, "PROC_STATM_PATH", proc_statm)
-    monkeypatch.setattr(srv, "CGROUP_V2_MEMORY_CURRENT_PATH", memory_current)
-    monkeypatch.setattr(srv, "CGROUP_V2_MEMORY_MAX_PATH", memory_max)
-    monkeypatch.setattr(srv.os, "sysconf", lambda _name: 4096)
+    monkeypatch.setattr(routes, "PROC_STATM_PATH", proc_statm)
+    monkeypatch.setattr(routes, "CGROUP_V2_MEMORY_CURRENT_PATH", memory_current)
+    monkeypatch.setattr(routes, "CGROUP_V2_MEMORY_MAX_PATH", memory_max)
+    monkeypatch.setattr(routes.os, "sysconf", lambda _name: 4096)
 
-    assert srv._memory_metadata() == {
+    assert routes._memory_metadata() == {
         "process_rss_mb": 1.0,
         "container_current_mb": 128.0,
         "container_limit_mb": 512.0,
@@ -216,13 +217,13 @@ def test_memory_metadata_reads_process_and_cgroup_values(monkeypatch, tmp_path):
 def test_memory_metadata_handles_missing_files(monkeypatch, tmp_path):
     missing = tmp_path / "missing"
 
-    monkeypatch.setattr(srv, "PROC_STATM_PATH", missing)
-    monkeypatch.setattr(srv, "CGROUP_V2_MEMORY_CURRENT_PATH", missing)
-    monkeypatch.setattr(srv, "CGROUP_V2_MEMORY_MAX_PATH", missing)
-    monkeypatch.setattr(srv, "CGROUP_V1_MEMORY_CURRENT_PATH", missing)
-    monkeypatch.setattr(srv, "CGROUP_V1_MEMORY_LIMIT_PATH", missing)
+    monkeypatch.setattr(routes, "PROC_STATM_PATH", missing)
+    monkeypatch.setattr(routes, "CGROUP_V2_MEMORY_CURRENT_PATH", missing)
+    monkeypatch.setattr(routes, "CGROUP_V2_MEMORY_MAX_PATH", missing)
+    monkeypatch.setattr(routes, "CGROUP_V1_MEMORY_CURRENT_PATH", missing)
+    monkeypatch.setattr(routes, "CGROUP_V1_MEMORY_LIMIT_PATH", missing)
 
-    assert srv._memory_metadata() == {
+    assert routes._memory_metadata() == {
         "process_rss_mb": None,
         "container_current_mb": None,
         "container_limit_mb": None,

--- a/tests/postgres_bootstrap.py
+++ b/tests/postgres_bootstrap.py
@@ -1,5 +1,3 @@
-"""Apply `docker/postgres_bootstrap.sql` to a running Postgres instance (used by Testcontainers)."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/test_css_tokens_smoke.py
+++ b/tests/unit/test_css_tokens_smoke.py
@@ -1,5 +1,3 @@
-"""Phase 7e - assert core design tokens and shell hooks exist in global CSS."""
-
 from pathlib import Path
 
 

--- a/tests/unit/test_recent_games_page_helpers.py
+++ b/tests/unit/test_recent_games_page_helpers.py
@@ -1,5 +1,3 @@
-"""Unit tests for Recent Games page UI helpers (slate bar, PBP insights)."""
-
 from __future__ import annotations
 
 import pandas as pd
@@ -54,8 +52,17 @@ def test_pbp_chart_subtitle_non_empty():
 def test_slate_date_label_format():
     label = _slate_date_label()
     assert len(label) >= 8
-    # e.g. "Mon, Jan 01, 2024" from strftime
+    # e.g. "Monday, Jan 01, 2024" from strftime — full weekday name at the front
     assert "," in label
+    assert label.split(",", 1)[0] in {
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    }
 
 
 def test_slate_summary_bar_structure():
@@ -115,9 +122,10 @@ def test_flow_legend_and_stats_known_game():
     assert isinstance(legend, html.Div)
     flat = str(legend)
     assert "Miami Heat @ Denver Nuggets" in flat
-    assert "DEN 94" in flat
-    assert "MIA 89" in flat
-    assert "Final" in flat
+    # Score and series chip live in the game card above the chart, not duplicated here.
+    assert "DEN 94" not in flat
+    assert "MIA 89" not in flat
+    assert "Final" not in flat
     assert "(BKN @ ATL)" not in flat
     assert "Chart context" not in flat
     assert "Max lead" in flat
@@ -127,6 +135,5 @@ def test_flow_legend_and_stats_known_game():
     assert "recent-games-pbp-heading" in flat
     assert "plays" in meta
     assert meta["plays"] != "-"
-    assert meta["winner"] == "DEN"
     assert meta["home_pct_leading"] != "-"
     assert meta["away_pct_leading"] != "-"

--- a/tests/unit/test_schedule_page_helpers.py
+++ b/tests/unit/test_schedule_page_helpers.py
@@ -1,5 +1,3 @@
-"""Unit tests for schedule page helpers and tonight's card builder."""
-
 from __future__ import annotations
 
 from unittest.mock import patch


### PR DESCRIPTION
### Description
Reduces vertical clutter on the Recent Games page so the play-by-play chart is visible without scrolling, plus internal cleanup of `server.py` and module docstrings.

## Added
- `src/routes.py` with the internal ops endpoints (`/internal/refresh-data`, `/internal/health`), memory/token helpers, and a `register_routes(server)` hook.

## Updated
- Recent Games page: full weekday name in the title, removed score/series duplicated between the game card and the chart heading, and made the chart height viewport-aware.
- `server.py` now just wires the app and calls `register_routes`, keeping only layout concerns.

## Deleted
- Module-level `"""` docstrings across `src/` and `tests/`.