### PR TITLE
feat: add biggest-run highlight, team filter, and winner cues

### DIFF
--- a/src/pages/overview.py
+++ b/src/pages/overview.py
@@ -102,8 +102,24 @@ def create_standings_table(conference_name, data):
     )
 
 
-def create_player_value_analysis_chart():
+_VALUE_ANALYSIS_ALL_TEAMS = "All Teams"
+
+
+def _player_value_team_options() -> list[dict]:
+    """Dropdown options for the Player Value Analysis team filter (All Teams + each team)."""
+    df = get_table("contract_value_analysis")
+    teams = sorted(df["team"].dropna().astype(str).unique()) if df is not None else []
+    return [{"label": _VALUE_ANALYSIS_ALL_TEAMS, "value": _VALUE_ANALYSIS_ALL_TEAMS}] + [
+        {"label": team, "value": team} for team in teams
+    ]
+
+
+def create_player_value_analysis_chart(team: str | None = None):
     contract_value_analysis_df = get_table("contract_value_analysis")
+    if team and team != _VALUE_ANALYSIS_ALL_TEAMS:
+        contract_value_analysis_df = contract_value_analysis_df[
+            contract_value_analysis_df["team"] == team
+        ]
     fig = px.scatter(
         contract_value_analysis_df,
         x="salary",
@@ -382,7 +398,17 @@ def overview_layout() -> html.Div:
                 [
                     dbc.Col(
                         [
-                            section_header("Player Value Analysis"),
+                            section_header(
+                                "Player Value Analysis",
+                                control=dcc.Dropdown(
+                                    id="player-value-team-filter",
+                                    options=_player_value_team_options(),
+                                    value=_VALUE_ANALYSIS_ALL_TEAMS,
+                                    clearable=False,
+                                    className="dash-dropdown",
+                                    style={"width": "150px"},
+                                ),
+                            ),
                             dcc.Graph(
                                 id="player-value-analysis-plot",
                                 figure=create_player_value_analysis_chart(),
@@ -416,3 +442,11 @@ def overview_layout() -> html.Div:
 )
 def update_scoring_efficiency_table(selected_season):
     return _scoring_efficiency_records(selected_season)
+
+
+@callback(
+    Output("player-value-analysis-plot", "figure"),
+    Input("player-value-team-filter", "value"),
+)
+def update_player_value_analysis_plot(selected_team):
+    return create_player_value_analysis_chart(team=selected_team)

--- a/src/pages/recent_games.py
+++ b/src/pages/recent_games.py
@@ -11,7 +11,11 @@ from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 
 from src.data_access.cache import get_table
-from src.recent_games_helpers import build_game_card_specs, pbp_flow_stats
+from src.recent_games_helpers import (
+    biggest_scoring_run,
+    build_game_card_specs,
+    pbp_flow_stats,
+)
 from src.shell import playoffs_enabled
 from src.theme.plotly import TRACE_HOVERLABEL, apply_dark_layout
 from src.ui.tables import dark_datatable
@@ -92,7 +96,7 @@ def _slate_summary_bar() -> html.Div:
 def _pbp_stat_tile(label: str, value: object) -> html.Div:
     return html.Div(
         [
-            html.Div(label, className="recent-games-pbp-stat-lbl"),
+            html.Div(label, className="app-label recent-games-pbp-stat-lbl"),
             html.Div(str(value), className="recent-games-pbp-stat-val"),
         ],
         className="recent-games-pbp-stat-tile",
@@ -157,10 +161,15 @@ def _flow_legend_and_stats(game_desc: str | None) -> tuple[html.Div | str, dict]
     away_hex = str(r0.get("away_primary_color") or "").strip()
     away_full = str(r0.get("away_team_full") or "").strip()
     home_full = str(r0.get("home_team_full") or "").strip()
+    winner_abbr = str(r0.get("winning_team") or "").strip()
+
+    def _mark_winner(name: str, abbr: str) -> str:
+        return f"{name} (W)" if abbr and abbr == winner_abbr else name
+
     if away_full and home_full:
-        title_line = f"{away_full} @ {home_full}"
+        title_line = f"{_mark_winner(away_full, away_abbr)} @ {_mark_winner(home_full, home_abbr)}"
     elif away_abbr and home_abbr:
-        title_line = f"{away_abbr} @ {home_abbr}"
+        title_line = f"{_mark_winner(away_abbr, away_abbr)} @ {_mark_winner(home_abbr, home_abbr)}"
     else:
         title_line = (
             str(game_desc).replace(" Vs. ", " @ ").replace(" vs. ", " @ ").replace(" vs ", " @ ")
@@ -331,7 +340,7 @@ def render_game_cards(selected: str | None) -> html.Div:
                         className="recent-games-card-mid",
                     ),
                     html.Div(
-                        f"{spec.home_pts - spec.away_pts:+d} margin",
+                        f"{spec.winner_abbr} by {spec.margin}",
                         className="recent-games-card-margin",
                     ),
                 ],
@@ -696,4 +705,40 @@ def update_pbp_plot(selected_game):
         title="Score Differential",
     )
 
+    _annotate_biggest_run(fig, filtered_pbp)
+
     return fig
+
+
+def _annotate_biggest_run(fig, filtered_pbp: pd.DataFrame) -> None:
+    """Shade the winning team's biggest scoring run and label it (e.g. "16-3 run")."""
+    run = biggest_scoring_run(filtered_pbp)
+    if run is None:
+        return
+
+    team_color = run.get("win_color") or "rgb(230, 224, 224)"
+    # x is reversed (minutes remaining); add_vrect normalizes x0/x1 order.
+    fig.add_vrect(
+        x0=run["x_start"],
+        x1=run["x_end"],
+        fillcolor=team_color,
+        opacity=0.12,
+        line_width=0,
+        layer="below",
+    )
+    fig.add_annotation(
+        xref="x",
+        yref="paper",
+        x=(run["x_start"] + run["x_end"]) / 2,
+        y=0.98,
+        xanchor="center",
+        yanchor="top",
+        showarrow=False,
+        text=f"Biggest run: {run['winner']} {run['label']}",
+        font=dict(color="rgb(230, 224, 224)", size=12, family="Arial Black, sans-serif"),
+        align="center",
+        bgcolor="rgba(0,0,0,0.55)",
+        bordercolor="rgba(230, 224, 224, 0.45)",
+        borderwidth=1,
+        borderpad=4,
+    )

--- a/src/pages/schedule.py
+++ b/src/pages/schedule.py
@@ -175,7 +175,10 @@ def create_tonight_games_cards() -> html.Div:
                         [
                             html.Div(
                                 [
-                                    html.Span("Avg team rank", className="schedule-card-stat-lbl"),
+                                    html.Span(
+                                        "Avg team rank",
+                                        className="app-label schedule-card-stat-lbl",
+                                    ),
                                     html.Span(
                                         _fmt_rank(row.get("avg_team_rank")),
                                         className="schedule-card-stat-val",
@@ -185,7 +188,9 @@ def create_tonight_games_cards() -> html.Div:
                             ),
                             html.Div(
                                 [
-                                    html.Span("Home win %", className="schedule-card-stat-lbl"),
+                                    html.Span(
+                                        "Home win %", className="app-label schedule-card-stat-lbl"
+                                    ),
                                     html.Span(
                                         _fmt_pct(row.get("home_team_predicted_win_pct")),
                                         className="schedule-card-stat-val",
@@ -195,7 +200,9 @@ def create_tonight_games_cards() -> html.Div:
                             ),
                             html.Div(
                                 [
-                                    html.Span("Road win %", className="schedule-card-stat-lbl"),
+                                    html.Span(
+                                        "Road win %", className="app-label schedule-card-stat-lbl"
+                                    ),
                                     html.Span(
                                         _fmt_pct(row.get("away_team_predicted_win_pct")),
                                         className="schedule-card-stat-val",
@@ -529,7 +536,7 @@ def schedule_layout() -> html.Div:
                     ),
                     html.Div(
                         [
-                            html.Label("Schedule view", className="schedule-field-label"),
+                            html.Label("Schedule view", className="app-label schedule-field-label"),
                             dcc.Dropdown(
                                 id="schedule-table-selector",
                                 options=SCHEDULE_TABLE_OPTIONS,
@@ -553,7 +560,7 @@ def schedule_layout() -> html.Div:
                     ),
                     html.Div(
                         [
-                            html.Label("Analysis plot", className="schedule-field-label"),
+                            html.Label("Analysis plot", className="app-label schedule-field-label"),
                             dcc.Dropdown(
                                 id="schedule-plot-selector",
                                 options=SCHEDULE_PLOT_OPTIONS,

--- a/src/pages/team_analysis.py
+++ b/src/pages/team_analysis.py
@@ -74,7 +74,7 @@ def _dark_message_figure(message: str) -> go.Figure:
 
 
 def _team_kpi_section_title(text: str) -> html.Div:
-    return html.Div(text, className="team-kpi-card__title")
+    return html.Div(text, className="app-label team-kpi-card__title")
 
 
 def _fmt_num(x: object, *, decimals: int = 1) -> str:

--- a/src/recent_games_helpers.py
+++ b/src/recent_games_helpers.py
@@ -113,6 +113,143 @@ def build_game_card_specs(pbp_df: pd.DataFrame, teams_df: pd.DataFrame) -> list[
     return out
 
 
+def biggest_scoring_run(
+    pbp_events: pd.DataFrame,
+    *,
+    min_net: int = 8,
+    max_side: int = 30,
+    max_span_minutes: float = 6.0,
+    max_loser_ratio: float = 0.40,
+) -> dict[str, Any] | None:
+    """Find the winning team's most impactful concentrated scoring run.
+
+    Scans the game's scoring events and returns the contiguous stretch that
+    maximizes the winner's net advantage (e.g. a 16-3 run), bounded so it reads
+    as a *clean run* rather than "outscored over a half":
+
+    - ``min_net``: lower bound on (winner_pts - loser_pts). Surfaces an 8-0 in a
+      close game while rejecting a 17-14 (net 3).
+    - ``max_side``: cap on points per side, so neither number balloons past ~30.
+    - ``max_span_minutes``: cap on the run's game-clock duration, keeping it a
+      concentrated burst instead of a slow grind across two quarters.
+    - ``max_loser_ratio``: cap on loser_pts / winner_pts. Without it, maximizing
+      net surfaces choppy "24-13" stretches (opponent share 0.54) that are really
+      just trading baskets. At 0.40 a 22-8 (0.36) survives but a 24-13 does not.
+
+    The optimal window always starts and ends on a winner basket (a trailing
+    opponent score only drags net down), so the opponent's points sit *inside*
+    the run -- exactly how a "16-3" is described colloquially.
+
+    A run is **always** returned for any game the winner actually scored in: when
+    no stretch clears every bound (e.g. a low-scoring defensive game with no real
+    run), the best concentrated net window is returned with ``qualified=False``
+    so callers can still label it. ``None`` only comes back for empty/invalid data
+    or a tie/unknown winner.
+
+    Returns a dict describing the run (winner-first label, team color, the
+    ``time_remaining_final`` span so the caller can band/annotate the plot, and a
+    ``qualified`` flag), or ``None``.
+    """
+    needed = {
+        "time_remaining_final",
+        "score_home",
+        "score_away",
+        "home_team",
+        "away_team",
+        "winning_team",
+    }
+    if pbp_events is None or pbp_events.empty or not needed <= set(pbp_events.columns):
+        return None
+
+    g = pbp_events.sort_values("time_remaining_final", ascending=False).reset_index(drop=True)
+
+    winners = g["winning_team"].dropna().astype(str)
+    winners = winners[winners.str.upper() != "TIE"]
+    if winners.empty:
+        return None
+    winner = winners.iloc[0]
+    home = str(g["home_team"].iloc[0])
+    winner_is_home = winner == home
+
+    sh = pd.to_numeric(g["score_home"], errors="coerce").ffill().fillna(0)
+    sa = pd.to_numeric(g["score_away"], errors="coerce").ffill().fillna(0)
+    dh = sh.diff().fillna(sh).clip(lower=0)
+    da = sa.diff().fillna(sa).clip(lower=0)
+    win_pts = (dh if winner_is_home else da).to_numpy()
+    los_pts = (da if winner_is_home else dh).to_numpy()
+
+    scoring = (win_pts > 0) | (los_pts > 0)
+    if not scoring.any():
+        return None
+    wp = win_pts[scoring]
+    lp = los_pts[scoring]
+    ev = g.loc[scoring].reset_index(drop=True)
+    tr = pd.to_numeric(ev["time_remaining_final"], errors="coerce").to_numpy()
+
+    n = len(ev)
+    # Two candidates, both bounded by side/span and bookended by a winner basket:
+    #   strict  -> also clears min_net and the loser-ratio cap (a "clean" run)
+    #   fallback -> best net window regardless, so we always have something to show
+    best_strict: tuple[float, ...] | None = None
+    best_strict_ij: tuple[int, int] | None = None
+    best_fallback: tuple[float, ...] | None = None
+    best_fallback_ij: tuple[int, int] | None = None
+    for i in range(n):
+        if wp[i] == 0:
+            continue
+        w = 0.0
+        loss = 0.0
+        for j in range(i, n):
+            w += wp[j]
+            loss += lp[j]
+            if w > max_side or loss > max_side:
+                break
+            span = tr[i] - tr[j]
+            if span > max_span_minutes:
+                break
+            if wp[j] == 0:
+                continue
+            net = w - loss
+            # Max net, then bigger winner number, then fewer opponent points,
+            # then the tighter (shorter) burst.
+            key = (net, w, -loss, -span)
+            if best_fallback is None or key > best_fallback:
+                best_fallback = key
+                best_fallback_ij = (i, j)
+            if net < min_net or loss > max_loser_ratio * w:
+                continue
+            if best_strict is None or key > best_strict:
+                best_strict = key
+                best_strict_ij = (i, j)
+
+    qualified = best_strict_ij is not None
+    best_ij = best_strict_ij if qualified else best_fallback_ij
+    if best_ij is None:
+        return None
+
+    i, j = best_ij
+    win_total = int(wp[i : j + 1].sum())
+    los_total = int(lp[i : j + 1].sum())
+    color_col = "home_primary_color" if winner_is_home else "away_primary_color"
+    win_color = str(ev[color_col].iloc[i]) if color_col in ev.columns else None
+
+    return {
+        "winner": winner,
+        "win_pts": win_total,
+        "los_pts": los_total,
+        "label": f"{win_total}-{los_total}",
+        "qualified": qualified,
+        "win_color": win_color,
+        # x-axis (time_remaining_final) bounds of the run; x is reversed on the plot.
+        "x_start": float(tr[i]),
+        "x_end": float(tr[j]),
+        "quarter_start": str(ev["quarter"].iloc[i]) if "quarter" in ev.columns else None,
+        "quarter_end": str(ev["quarter"].iloc[j]) if "quarter" in ev.columns else None,
+        "clock_start": str(ev["time_quarter"].iloc[i]) if "time_quarter" in ev.columns else None,
+        "clock_end": str(ev["time_quarter"].iloc[j]) if "time_quarter" in ev.columns else None,
+    }
+
+
 def pbp_flow_stats(pbp_events: pd.DataFrame) -> dict[str, Any]:
     """Stats for the selected game's PBP event frame (transformed)."""
     empty: dict[str, Any] = {

--- a/src/ui/sections.py
+++ b/src/ui/sections.py
@@ -43,11 +43,24 @@ def page_hero(
     return html.Div(children, className="app-page-hero py-3 text-center")
 
 
-def section_header(title: str, aside: str | None = None) -> html.Div:
+def section_header(
+    title: str, aside: str | None = None, control: Component | None = None
+) -> html.Div:
     row: list[Component] = [html.H4(title, className="mb-0")]
     if aside:
         row.append(html.Span(aside, className="text-muted small ms-2"))
+    base_cls = (
+        "app-section-header d-flex flex-wrap align-items-baseline justify-content-center mb-3"
+    )
+    if control is None:
+        return html.Div(row, className=base_cls)
+    # The control is absolutely positioned at the right edge so it stays out of the
+    # flow: the header keeps the title's height, so a paired plain-title header in the
+    # adjacent column still lines up without any spacer.
     return html.Div(
-        row,
-        className="app-section-header d-flex flex-wrap align-items-baseline justify-content-center mb-3",
+        [
+            html.Div(row, className="d-flex align-items-baseline"),
+            html.Div(control, className="app-section-header-control"),
+        ],
+        className=f"{base_cls} position-relative",
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import date, datetime
 
 from dash import dcc
@@ -55,13 +56,19 @@ def pbp_transformer(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
 
     end_rows = []
     for _, row in last_records.iterrows():
+        # Synthetic "0:00 final" marker so the line/score reaches the end of the game.
+        # time_remaining_final counts down past 0 into OT (OT1: 0 -> -5, OT2: -5 -> -10),
+        # so 0:00 of the final period is the next 5-min boundary at/below the last play,
+        # not a hardcoded 0 (which for OT lands back at the end of regulation).
+        last_t = float(row["time_remaining_final"])
+        end_t = 0.0 if last_t >= 0 else -5.0 * math.ceil(-last_t / 5.0)
         end_rows.append(
             {
                 **row.to_dict(),
                 "time_quarter": "0:00",
-                "time_remaining_final": 0,
+                "time_remaining_final": end_t,
                 "prev_time": row["time_remaining_final"],
-                "next_time": 0,
+                "next_time": end_t,
                 "time_difference": 0,
             }
         )

--- a/static/styles.css
+++ b/static/styles.css
@@ -21,6 +21,8 @@
   --text: #e8e6e3;
   --text-muted: #8d9694;
   --text-accent: #7ee8d4;
+  /* --text-accent as raw r,g,b so components can tint it: rgba(var(--accent-rgb), a) */
+  --accent-rgb: 126, 232, 212;
 
   /* Brand & semantics */
   --accent: #4fd1c5;
@@ -64,6 +66,13 @@ h3 {
   text-align: center;
 }
 
+/* Small uppercase caption shared by KPI titles, field labels and stat captions.
+   Pair with a component class for per-label size/spacing (e.g. "app-label foo-lbl"). */
+.app-label {
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 /* -----------------------------------------------------------------------------
    Bootstrap / DBC (cards)
    App shell tab rail lives in static/tab_shell.css (.nba-shell-tabs) so SLATE
@@ -89,7 +98,7 @@ h3 {
 }
 
 .scoring-efficiency-legend-ts {
-  color: #7ee8d4;
+  color: var(--text-accent);
   font-weight: 600;
 }
 
@@ -190,8 +199,6 @@ h3 {
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-muted);
   margin-bottom: var(--space-2);
   width: 100%;
 }
@@ -288,7 +295,7 @@ h3 {
 
 /* Row hover: inset ring only - avoids overriding inline conditional backgrounds. */
 .dash-spreadsheet tbody tr:hover .dash-cell {
-  box-shadow: inset 0 0 0 1px rgba(127, 232, 212, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), 0.4);
 }
 
 .dash-spreadsheet .dash-header-cell,
@@ -384,6 +391,23 @@ img[src*="/nba"] {
   text-align: center;
   color: var(--text);
   font-weight: 600;
+}
+
+/* Optional inline control (e.g. a filter dropdown) pinned to the right of a section
+   header. Absolute so it never adds height — paired plot headers stay aligned. */
+.app-section-header-control {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  /* Sit above the sibling plot so the open dropdown menu isn't painted over. */
+  z-index: 30;
+}
+
+.app-section-header-control .Select-menu-outer {
+  z-index: 30;
 }
 
 /* -----------------------------------------------------------------------------
@@ -546,9 +570,7 @@ img[src*="/nba"] {
   display: block;
   font-size: 0.72rem;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-muted);
   margin-bottom: 6px;
 }
 
@@ -699,9 +721,9 @@ img[src*="/nba"] {
 }
 
 .schedule-card-team--value {
-  border-color: rgba(126, 232, 212, 0.45);
-  background-color: rgba(126, 232, 212, 0.12);
-  box-shadow: 0 0 0 1px rgba(126, 232, 212, 0.08);
+  border-color: rgba(var(--accent-rgb),0.45);
+  background-color: rgba(var(--accent-rgb),0.12);
+  box-shadow: 0 0 0 1px rgba(var(--accent-rgb),0.08);
 }
 
 .schedule-card-at {
@@ -761,9 +783,7 @@ img[src*="/nba"] {
 .schedule-card-stat-lbl {
   display: block;
   font-size: 0.62rem;
-  text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-muted);
   margin-bottom: 4px;
 }
 
@@ -927,7 +947,7 @@ img[src*="/nba"] {
 }
 
 .recent-games-margin-chip--home {
-  background-color: rgba(126, 232, 212, 0.1);
+  background-color: rgba(var(--accent-rgb),0.1);
   color: var(--text);
 }
 
@@ -966,9 +986,7 @@ img[src*="/nba"] {
 
 .recent-games-pbp-stat-lbl {
   font-size: 0.68rem;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-muted);
   margin-bottom: 4px;
 }
 
@@ -1099,12 +1117,12 @@ img[src*="/nba"] {
 }
 
 .recent-games-card:hover {
-  border-color: rgba(126, 232, 212, 0.35);
+  border-color: rgba(var(--accent-rgb),0.35);
 }
 
 .recent-games-card--selected {
   border-color: var(--text-accent);
-  box-shadow: 0 0 0 1px rgba(126, 232, 212, 0.25);
+  box-shadow: 0 0 0 1px rgba(var(--accent-rgb),0.25);
 }
 
 .recent-games-card-top {
@@ -1407,7 +1425,7 @@ img[src*="/nba"] {
 }
 
 .team-panel-injury-badge--default {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: var(--border-subtle);
   color: var(--text-muted);
 }
 

--- a/tests/unit/pbp_transformer_test.py
+++ b/tests/unit/pbp_transformer_test.py
@@ -64,6 +64,42 @@ def test_pbp_transformer_empty_df():
     assert k.empty and d.empty
 
 
+def _minimal_pbp(times: list[float], scorers: list[str]) -> pd.DataFrame:
+    n = len(times)
+    return pd.DataFrame(
+        {
+            "game_description": ["G"] * n,
+            "time_remaining_final": times,
+            "scoring_team": scorers,
+            "leading_team": scorers,
+            "home_team": ["DEN"] * n,
+            "away_team": ["MIA"] * n,
+            "home_fill": ["DEN"] * n,
+            "away_fill": ["MIA"] * n,
+            "time_quarter": ["x"] * n,
+            "quarter": ["q"] * n,
+        }
+    )
+
+
+def test_pbp_transformer_end_row_at_zero_for_regulation():
+    # Last play is in regulation (positive clock) -> 0:00 marker sits at end of Q4 (0.0).
+    _, plot = pbp_transformer(_minimal_pbp([48.0, 1.0], ["DEN", "MIA"]))
+    end = plot[plot["time_quarter"] == "0:00"]
+    assert end["time_remaining_final"].tolist() == [0.0]
+
+
+def test_pbp_transformer_end_row_at_period_boundary_for_overtime():
+    # Clock counts past 0 into OT (OT1: 0 -> -5). The 0:00 marker must land at the OT
+    # period boundary, not back at end of regulation (the bug that drew a stray point).
+    _, plot_ot1 = pbp_transformer(_minimal_pbp([48.0, -0.5, -4.9], ["DEN", "MIA", "DEN"]))
+    assert plot_ot1[plot_ot1["time_quarter"] == "0:00"]["time_remaining_final"].tolist() == [-5.0]
+
+    # Second overtime (-5 -> -10) lands on -10.0.
+    _, plot_ot2 = pbp_transformer(_minimal_pbp([48.0, -6.0, -9.5], ["DEN", "MIA", "DEN"]))
+    assert plot_ot2[plot_ot2["time_quarter"] == "0:00"]["time_remaining_final"].tolist() == [-10.0]
+
+
 def test_pbp_transformer_adds_tie_column_when_absent_from_pivot(pbp_fixture):
     sub = pbp_fixture[pbp_fixture["leading_team_text"] != "TIE"].copy()
     kpis, _ = pbp_transformer(sub)

--- a/tests/unit/test_overview_page_helpers.py
+++ b/tests/unit/test_overview_page_helpers.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import pandas as pd
+
+from src.pages import overview
+
+
+def _fake_contract_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "player": ["A", "B", "C", "D"],
+            "team": ["DEN", "DEN", "LAL", "BOS"],
+            "salary": [1_000_000, 5_000_000, 30_000_000, 12_000_000],
+            "avg_mvp_score": [5.0, 12.0, 40.0, 22.0],
+            "color_var": ["Bad Value", "Normal", "Superstars", "Great Value"],
+            "games_played": [50, 60, 70, 65],
+            "games_missed": [20, 10, 5, 7],
+        }
+    )
+
+
+def _npoints(fig) -> int:
+    return sum(len(trace.x) for trace in fig.data)
+
+
+def test_player_value_team_options_lists_all_teams_then_sorted_teams():
+    with patch.object(overview, "get_table", return_value=_fake_contract_df()):
+        opts = overview._player_value_team_options()
+    assert opts[0] == {"label": "All Teams", "value": "All Teams"}
+    assert [o["value"] for o in opts[1:]] == ["BOS", "DEN", "LAL"]  # sorted, de-duped
+
+
+def test_player_value_chart_unfiltered_shows_every_player():
+    with patch.object(overview, "get_table", return_value=_fake_contract_df()):
+        fig = overview.create_player_value_analysis_chart()
+        fig_all = overview.create_player_value_analysis_chart(team="All Teams")
+    assert _npoints(fig) == 4
+    assert _npoints(fig_all) == 4
+
+
+def test_player_value_chart_filters_to_one_team():
+    with patch.object(overview, "get_table", return_value=_fake_contract_df()):
+        fig = overview.create_player_value_analysis_chart(team="DEN")
+    assert _npoints(fig) == 2  # only the two DEN players

--- a/tests/unit/test_recent_games_helpers.py
+++ b/tests/unit/test_recent_games_helpers.py
@@ -1,6 +1,101 @@
 import pandas as pd
 
-from src.recent_games_helpers import build_game_card_specs, pbp_flow_stats
+from src.recent_games_helpers import (
+    biggest_scoring_run,
+    build_game_card_specs,
+    pbp_flow_stats,
+)
+
+
+def _run_events(rows):
+    """Build a minimal scoring-event frame: (time_remaining, score_home, score_away)."""
+    return pd.DataFrame(
+        {
+            "time_remaining_final": [r[0] for r in rows],
+            "score_home": [r[1] for r in rows],
+            "score_away": [r[2] for r in rows],
+            "home_team": "DEN",
+            "away_team": "MIA",
+            "winning_team": "DEN",
+            "home_primary_color": "#4d90cd",
+            "away_primary_color": "#98002e",
+            "quarter": "1st Quarter",
+            "time_quarter": "0:00",
+        }
+    )
+
+
+def test_biggest_scoring_run_finds_winner_burst():
+    # DEN (home) scores 12 unanswered, then MIA gets 2 -> 12-2 run.
+    rows = [(48.0, 0, 0)]
+    rows += [(47.0 - k, 3 * (k + 1), 0) for k in range(4)]  # DEN 12-0
+    rows += [(42.0, 12, 2)]  # MIA answers
+    df = _run_events(rows)
+    run = biggest_scoring_run(df, min_net=8)
+    assert run is not None
+    assert run["qualified"] is True
+    assert run["winner"] == "DEN"
+    assert run["win_pts"] == 12
+    assert run["los_pts"] in (0, 2)
+    assert run["label"] == f"{run['win_pts']}-{run['los_pts']}"
+
+
+def test_biggest_scoring_run_ratio_cap_avoids_choppy_stretch():
+    # Build a choppy lead-the-whole-way stretch (DEN nets +11 but opponent keeps
+    # answering, share ~0.5) preceded by a clean 12-2 burst. The choppy window has
+    # the higher raw net, so only the ratio cap steers us to the clean run.
+    rows = [(48.0, 0, 0)]
+    # clean 12-2 burst
+    rows += [(47.0, 3, 0), (46.5, 6, 0), (46.0, 9, 0), (45.5, 12, 0), (45.0, 12, 2)]
+    # choppy trade: DEN and MIA alternate 3s, DEN stays ~one basket ahead
+    sh, sa, t = 12, 2, 44.5
+    for _ in range(8):
+        sh += 3
+        rows.append((t, sh, sa))
+        t -= 0.3
+        sa += 3
+        rows.append((t, sh, sa))
+        t -= 0.3
+    df = _run_events(rows)
+    run = biggest_scoring_run(df, min_net=8, max_loser_ratio=0.40)
+    assert run is not None
+    assert run["los_pts"] <= 0.40 * run["win_pts"]
+    assert run["qualified"] is True
+
+
+def test_biggest_scoring_run_always_returns_when_no_clean_run():
+    # Tight defensive trades: nothing clears min_net=8, but a run is still forced.
+    rows = [(48.0 - 0.5 * k, 2 * (k // 2 + (k % 2)), 2 * ((k + 1) // 2)) for k in range(12)]
+    df = _run_events(rows)
+    run = biggest_scoring_run(df, min_net=8)
+    assert run is not None
+    assert run["qualified"] is False
+    assert run["win_pts"] >= run["los_pts"]  # still the winner's best stretch
+
+
+def test_biggest_scoring_run_handles_overtime():
+    # In OT the clock continues past 0 into negative time_remaining_final. A run
+    # there (or spanning Q4 -> OT) must still sort chronologically, measure a
+    # positive span, and land its band in the OT region (negative x).
+    rows = [(0.5, 100, 100)]  # tie at end of regulation
+    rows += [(-0.5, 103, 100), (-1.5, 106, 100), (-2.5, 109, 100), (-3.5, 112, 100)]
+    df = _run_events(rows)
+    df["quarter"] = ["4th Quarter"] + ["1st Overtime"] * 4
+    run = biggest_scoring_run(df)
+    assert run is not None
+    assert run["label"] == "12-0"
+    assert run["x_start"] < 0 and run["x_end"] < 0  # band sits in OT
+    assert run["x_start"] > run["x_end"]  # ordered start (earlier) -> end (later)
+    assert run["x_start"] - run["x_end"] > 0  # positive span across the OT clock
+
+
+def test_biggest_scoring_run_on_real_fixture(pbp_fixture):
+    run = biggest_scoring_run(pbp_fixture)
+    assert run is not None
+    assert run["winner"] == "DEN"
+    assert run["win_pts"] - run["los_pts"] >= 8
+    assert run["win_pts"] <= 30 and run["los_pts"] <= 30
+    assert run["los_pts"] <= 0.40 * run["win_pts"]
 
 
 def test_pbp_flow_stats_basic():

--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -31,3 +31,18 @@ def test_page_hero_with_title_meta():
 def test_section_header_with_aside():
     s = section_header("Main", aside="note")
     assert "Main" in str(s) and "note" in str(s)
+
+
+def test_section_header_plain_has_no_positioning():
+    s = section_header("Main")
+    assert "position-relative" not in s.className
+
+
+def test_section_header_with_control_pins_it_right():
+    control = html.Span("filter", id="my-filter")
+    s = section_header("Main", control=control)
+    # Header becomes positioning context; control sits in the absolute right-edge wrapper.
+    assert "position-relative" in s.className
+    wrapper = s.children[1]
+    assert wrapper.className == "app-section-header-control"
+    assert "my-filter" in str(wrapper)


### PR DESCRIPTION
### Description
Quality-of-life improvements to the Recent Games and Overview pages, plus an overtime play-by-play fix and CSS cleanup.

## Added
- Biggest scoring-run highlight on the play-by-play plot (team-colored band + label), bounded so it reads as a clean run.
- Team filter dropdown on the Player Value Analysis chart, rendered as an inline header control.

## Updated
- Recent Games: mark the winner with `(W)` in the matchup heading and name them in each card's margin line.
- Fix overtime play-by-play: the synthetic `0:00` marker now lands at the OT period boundary instead of back at end of regulation (removes a stray point and a phantom run spike).
- DRY the stylesheet: add an `--accent-rgb` token and a shared `.app-label` utility.