### PR TITLE
chore: add browser e2e coverage

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -68,10 +68,12 @@ jobs:
       - name: Checkout the Repo
         uses: actions/checkout@v4
 
-      - name: Install Chromium and WebDriver
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y chromium chromium-driver
+      - name: Install Chrome and WebDriver
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: stable
+          install-chromedriver: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -84,7 +86,7 @@ jobs:
 
       - name: Run Browser E2E Tests
         env:
-          DASH_TEST_CHROMEPATH: /usr/bin/chromium
+          DASH_TEST_CHROMEPATH: ${{ steps.setup-chrome.outputs.chrome-path }}
           RUN_E2E: "1"
         run: make test-e2e
 

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -61,9 +61,36 @@ jobs:
       - name: ty
         run: uv run ty check --output-format github
 
+  e2e:
+    name: Browser E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@v4
+
+      - name: Install Chromium and WebDriver
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y chromium chromium-driver
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Setup Environment
+        run: uv sync --group test
+
+      - name: Run Browser E2E Tests
+        env:
+          DASH_TEST_CHROMEPATH: /usr/bin/chromium
+          RUN_E2E: "1"
+        run: make test-e2e
+
   deploy:
     name: Deploy Pipeline
-    needs: [test, quality]
+    needs: [test, quality, e2e]
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ test-unit:
 	uv sync --group test
 	uv run pytest --color=yes tests/unit
 
+.PHONY: test-e2e
+test-e2e:
+	uv sync --group test
+	RUN_E2E=1 uv run pytest --color=yes tests/e2e --headless
+
 .PHONY: ci-test
 ci-test:
 	uv sync --group test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ markers = [
     "wip: work in progress",
     "infrastructure: mocks for dummy data (sql db, http endpoint etc)",
     "integration: needs Docker + Postgres (Testcontainers)",
-    "e2e: browser tests; run with RUN_E2E=1 (see tests/e2e/README.md)",
+    "e2e: browser tests; run with RUN_E2E=1",
 ]
 addopts = "-v"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ def _needs_postgres(config: pytest.Config) -> bool:
     normalized = [str(a).replace("\\", "/") for a in args if not str(a).startswith("-")]
     if not normalized:
         return True
+    if os.environ.get("RUN_E2E") != "1" and all("e2e" in p for p in normalized):
+        return False
     for p in normalized:
         if "integration" in p:
             return True
@@ -38,6 +40,15 @@ def _docker_available() -> bool:
         return True
     except Exception:
         return False
+
+
+def _is_test_area(item: pytest.Item, directory: str) -> bool:
+    normalized_path = str(item.path).replace("\\", "/")
+    return f"/{directory}/" in f"/{normalized_path}/"
+
+
+def _has_marker_or_path(item: pytest.Item, marker: str, directory: str) -> bool:
+    return item.get_closest_marker(marker) is not None or _is_test_area(item, directory)
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -72,12 +83,21 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     if getattr(config.option, "collectonly", False):
         return
+
+    if os.environ.get("RUN_E2E") != "1":
+        skip_e2e = pytest.mark.skip(reason="E2E tests are disabled; set RUN_E2E=1 to run them.")
+        for item in items:
+            if _has_marker_or_path(item, "e2e", "tests/e2e"):
+                item.add_marker(skip_e2e)
+
     if not _needs_postgres(config):
         return
     if os.environ.get("SKIP_INTEGRATION") == "1":
         skip = pytest.mark.skip(reason="SKIP_INTEGRATION=1")
         for item in items:
-            if item.get_closest_marker("integration"):
+            if _has_marker_or_path(item, "integration", "tests/integration") or _has_marker_or_path(
+                item, "e2e", "tests/e2e"
+            ):
                 item.add_marker(skip)
         return
     if getattr(config, "_tc_engine", None) is None:
@@ -85,7 +105,9 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             reason="Docker is not available; integration tests need Testcontainers Postgres."
         )
         for item in items:
-            if item.get_closest_marker("integration"):
+            if _has_marker_or_path(item, "integration", "tests/integration") or _has_marker_or_path(
+                item, "e2e", "tests/e2e"
+            ):
                 item.add_marker(skip)
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def dashboard_app():
+    """Import the app after the session database snapshot is ready."""
+    from src.server import app
+
+    return app

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -49,6 +49,34 @@ def _inner_html(dash_duo, selector: str) -> str:
     return dash_duo.find_element(selector).get_attribute("innerHTML")
 
 
+def _plot_signature(dash_duo, selector: str) -> str:
+    return dash_duo.driver.execute_script(
+        """
+        const graph = document.querySelector(arguments[0] + ' .js-plotly-plot');
+        if (!graph) {
+            return '';
+        }
+        return JSON.stringify(
+            (graph.data || []).map((trace) => ({
+                name: trace.name,
+                x: trace.x,
+                y: trace.y,
+                customdata: trace.customdata,
+            }))
+        );
+        """,
+        selector,
+    )
+
+
+def _wait_for_plot_change(dash_duo, selector: str, previous_signature: str):
+    def has_changed(driver):
+        current_signature = _plot_signature(dash_duo, selector)
+        return current_signature if current_signature != previous_signature else False
+
+    return WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(has_changed)
+
+
 def _wait_for_html_change(dash_duo, selector: str, previous_html: str):
     def has_changed(driver):
         current_html = driver.find_element(By.CSS_SELECTOR, selector).get_attribute("innerHTML")
@@ -67,6 +95,23 @@ def _click_element(dash_duo, element) -> None:
         dash_duo.driver.execute_script("arguments[0].click();", element)
 
 
+def _dispatch_mouse_down(dash_duo, element) -> None:
+    dash_duo.driver.execute_script(
+        """
+        arguments[0].dispatchEvent(
+            new MouseEvent('mousedown', {
+                bubbles: true,
+                cancelable: true,
+                view: window,
+                button: 0,
+                buttons: 1,
+            })
+        );
+        """,
+        element,
+    )
+
+
 def _select_dcc_dropdown(
     dash_duo, selector: str, *, value: str | None = None, index: int | None = None
 ):
@@ -75,7 +120,33 @@ def _select_dcc_dropdown(
         "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});",
         dropdown,
     )
-    dash_duo.select_dcc_dropdown(dropdown, value=value, index=index)
+    control = dropdown.find_element(By.CSS_SELECTOR, ".Select-control")
+    _dispatch_mouse_down(dash_duo, control)
+
+    def find_options(driver):
+        options = driver.find_elements(By.CSS_SELECTOR, f"{selector} div.VirtualizedSelectOption")
+        return options or False
+
+    options = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_options)
+    if isinstance(index, int):
+        option = options[index]
+        expected_label = option.text
+    else:
+        option = next((option for option in options if option.text == value), None)
+        if option is None:
+            raise AssertionError(f"Could not find dropdown option {value!r}")
+        expected_label = value
+
+    _dispatch_mouse_down(dash_duo, option)
+    if expected_label:
+        WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
+            lambda driver: any(
+                element.is_displayed() and element.text.strip() == expected_label
+                for element in driver.find_elements(
+                    By.CSS_SELECTOR, f"{selector} .Select-value-label"
+                )
+            )
+        )
 
 
 def _active_tab_text(driver) -> str:
@@ -136,9 +207,9 @@ def test_overview_filter_updates_player_value_chart(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#team-ratings-plot .js-plotly-plot")
     _wait_visible(dash_duo, "#player-value-analysis-plot .js-plotly-plot")
 
-    previous_html = _inner_html(dash_duo, "#player-value-analysis-plot")
+    previous_signature = _plot_signature(dash_duo, "#player-value-analysis-plot")
     _select_dcc_dropdown(dash_duo, "#player-value-team-filter", value="BOS")
-    _wait_for_html_change(dash_duo, "#player-value-analysis-plot", previous_html)
+    _wait_for_plot_change(dash_duo, "#player-value-analysis-plot", previous_signature)
 
 
 def test_schedule_controls_update_table_and_plot(dash_duo, dashboard_app):
@@ -151,11 +222,11 @@ def test_schedule_controls_update_table_and_plot(dash_duo, dashboard_app):
     _select_dcc_dropdown(dash_duo, "#schedule-table-selector", value="Full Schedule")
     _wait_visible(dash_duo, "#schedule-full-table")
 
-    previous_html = _inner_html(dash_duo, "#schedule-plot")
+    previous_signature = _plot_signature(dash_duo, "#schedule-plot")
     _select_dcc_dropdown(
         dash_duo, "#schedule-plot-selector", value="Team Comebacks Analysis (Regular Season)"
     )
-    _wait_for_html_change(dash_duo, "#schedule-plot", previous_html)
+    _wait_for_plot_change(dash_duo, "#schedule-plot", previous_signature)
 
 
 def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
@@ -165,13 +236,13 @@ def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#team-selector")
     _wait_visible(dash_duo, "#mov-plot .js-plotly-plot")
 
-    previous_html = _inner_html(dash_duo, "#mov-plot")
+    previous_signature = _plot_signature(dash_duo, "#mov-plot")
     previous_kpi_html = _inner_html(dash_duo, "#kpi-boxes-1")
     _select_dcc_dropdown(dash_duo, "#team-selector", value="Los Angeles Lakers")
     _wait_for_visible_text(dash_duo, "#team-selector .Select-value-label", "Los Angeles Lakers")
     _wait_for_html_change(dash_duo, "#kpi-boxes-1", previous_kpi_html)
     _wait_for_nonempty_text(dash_duo, "#team-payroll-value")
-    _wait_for_html_change(dash_duo, "#mov-plot", previous_html)
+    _wait_for_plot_change(dash_duo, "#mov-plot", previous_signature)
 
 
 def test_recent_game_selection_updates_play_by_play_chart(dash_duo, dashboard_app):
@@ -181,7 +252,7 @@ def test_recent_game_selection_updates_play_by_play_chart(dash_duo, dashboard_ap
     _wait_visible(dash_duo, "#recent-games-card-strip .recent-games-card")
     _wait_visible(dash_duo, "#pbp-analysis-plot .js-plotly-plot")
 
-    previous_html = _inner_html(dash_duo, "#pbp-analysis-plot")
+    previous_signature = _plot_signature(dash_duo, "#pbp-analysis-plot")
 
     def find_game_cards(driver):
         cards = driver.find_elements(By.CSS_SELECTOR, "#recent-games-card-strip .recent-games-card")
@@ -190,7 +261,7 @@ def test_recent_game_selection_updates_play_by_play_chart(dash_duo, dashboard_ap
 
     cards = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_game_cards)
     _click_element(dash_duo, cards[1])
-    _wait_for_html_change(dash_duo, "#pbp-analysis-plot", previous_html)
+    _wait_for_plot_change(dash_duo, "#pbp-analysis-plot", previous_signature)
 
 
 def test_social_team_selection_updates_sentiment_chart(dash_duo, dashboard_app):
@@ -200,6 +271,6 @@ def test_social_team_selection_updates_sentiment_chart(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#social-media-team-selector")
     _wait_visible(dash_duo, "#social-media-plot .js-plotly-plot")
 
-    previous_html = _inner_html(dash_duo, "#social-media-plot")
+    previous_signature = _plot_signature(dash_duo, "#social-media-plot")
     _select_dcc_dropdown(dash_duo, "#social-media-team-selector", value="GSW")
-    _wait_for_html_change(dash_duo, "#social-media-plot", previous_html)
+    _wait_for_plot_change(dash_duo, "#social-media-plot", previous_signature)

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 from selenium.common.exceptions import ElementClickInterceptedException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 
@@ -113,9 +112,7 @@ def _dispatch_mouse_down(dash_duo, element) -> None:
     )
 
 
-def _select_dcc_dropdown(
-    dash_duo, selector: str, *, value: str | None = None, index: int | None = None
-):
+def _select_dcc_dropdown(dash_duo, selector: str, *, value: str) -> None:
     dropdown = dash_duo.find_element(selector)
     dash_duo.driver.execute_script(
         "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});",
@@ -124,40 +121,29 @@ def _select_dcc_dropdown(
     control = dropdown.find_element(By.CSS_SELECTOR, ".Select-control")
     _dispatch_mouse_down(dash_duo, control)
 
-    def find_options(driver):
-        options = driver.find_elements(By.CSS_SELECTOR, f"{selector} div.VirtualizedSelectOption")
-        return options or False
-
-    options = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_options)
-    if isinstance(index, int):
-        option = options[index]
-        option_index = index
-        expected_label = option.text
-    else:
-        option_index, option = next(
-            (
-                (option_index, option)
-                for option_index, option in enumerate(options)
-                if option.text == value
-            ),
-            (None, None),
-        )
-        if option_index is None or option is None:
-            raise AssertionError(f"Could not find dropdown option {value!r}")
-        expected_label = value
-
+    # The option list is virtualized and opens scrolled to the current value, so the wanted
+    # option may not be in the DOM at all. Typing narrows the list and resets it to the top.
     input_element = dropdown.find_element(By.CSS_SELECTOR, ".Select-input input")
-    input_element.send_keys(Keys.HOME, *(Keys.ARROW_DOWN for _ in range(option_index)))
-    input_element.send_keys(Keys.ENTER)
-    if expected_label:
-        WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
-            lambda driver: any(
-                element.is_displayed() and element.text.strip() == expected_label
-                for element in driver.find_elements(
-                    By.CSS_SELECTOR, f"{selector} .Select-value-label"
-                )
-            )
+    input_element.send_keys(value)
+
+    def find_option(driver):
+        for option in driver.find_elements(
+            By.CSS_SELECTOR, f"{selector} div.VirtualizedSelectOption"
+        ):
+            if option.is_displayed() and option.text.strip() == value:
+                return option
+        return False
+
+    option = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_option)
+    # react-select v1 commits the choice on mousedown; a real click gets intercepted.
+    _dispatch_mouse_down(dash_duo, option)
+
+    WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
+        lambda driver: any(
+            element.is_displayed() and element.text.strip() == value
+            for element in driver.find_elements(By.CSS_SELECTOR, f"{selector} .Select-value-label")
         )
+    )
 
 
 def _active_tab_text(driver) -> str:
@@ -249,8 +235,8 @@ def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
 
     previous_signature = _plot_signature(dash_duo, "#mov-plot")
     previous_kpi_html = _inner_html(dash_duo, "#kpi-boxes-1")
-    _select_dcc_dropdown(dash_duo, "#team-selector", value="Los Angeles Lakers")
-    _wait_for_visible_text(dash_duo, "#team-selector .Select-value-label", "Los Angeles Lakers")
+    _select_dcc_dropdown(dash_duo, "#team-selector", value="Denver Nuggets")
+    _wait_for_visible_text(dash_duo, "#team-selector .Select-value-label", "Denver Nuggets")
     _wait_for_html_change(dash_duo, "#kpi-boxes-1", previous_kpi_html)
     _wait_for_nonempty_text(dash_duo, "#team-payroll-value")
     _wait_for_plot_change(dash_duo, "#mov-plot", previous_signature)

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -71,25 +71,11 @@ def _select_dcc_dropdown(
     dash_duo, selector: str, *, value: str | None = None, index: int | None = None
 ):
     dropdown = dash_duo.find_element(selector)
-    control = dropdown.find_element(By.CSS_SELECTOR, ".Select-control")
-    _click_element(dash_duo, control)
-
-    def find_menu(driver):
-        menus = dropdown.find_elements(By.CSS_SELECTOR, "div.Select-menu-outer")
-        for menu in menus:
-            if menu.is_displayed():
-                return menu
-        return False
-
-    menu = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_menu)
-    options = menu.find_elements(By.CSS_SELECTOR, "div.VirtualizedSelectOption")
-    if isinstance(index, int):
-        option = options[index]
-    else:
-        option = next((option for option in options if option.text == value), None)
-        if option is None:
-            raise AssertionError(f"Could not find dropdown option {value!r}")
-    _click_element(dash_duo, option)
+    dash_duo.driver.execute_script(
+        "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});",
+        dropdown,
+    )
+    dash_duo.select_dcc_dropdown(dropdown, value=value, index=index)
 
 
 def _active_tab_text(driver) -> str:
@@ -180,9 +166,10 @@ def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#mov-plot .js-plotly-plot")
 
     previous_html = _inner_html(dash_duo, "#mov-plot")
+    previous_kpi_html = _inner_html(dash_duo, "#kpi-boxes-1")
     _select_dcc_dropdown(dash_duo, "#team-selector", value="Los Angeles Lakers")
     _wait_for_visible_text(dash_duo, "#team-selector .Select-value-label", "Los Angeles Lakers")
-    _wait_for_visible_text(dash_duo, "#kpi-boxes-1", "Team ratings")
+    _wait_for_html_change(dash_duo, "#kpi-boxes-1", previous_kpi_html)
     _wait_for_nonempty_text(dash_duo, "#team-payroll-value")
     _wait_for_html_change(dash_duo, "#mov-plot", previous_html)
 

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+pytestmark = pytest.mark.e2e
+
+
+def _wait_visible(dash_duo, selector: str):
+    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, selector))
+    )
+
+
+def _wait_for_visible_text(dash_duo, selector: str, expected: str):
+    def has_expected_text(driver):
+        elements = driver.find_elements(By.CSS_SELECTOR, selector)
+        for element in elements:
+            if element.is_displayed() and expected in element.text:
+                return element
+        return False
+
+    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_expected_text)
+
+
+def _wait_for_nonempty_text(dash_duo, selector: str):
+    def has_text(driver):
+        element = driver.find_element(By.CSS_SELECTOR, selector)
+        if element.is_displayed() and element.text.strip():
+            return element
+        return False
+
+    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_text)
+
+
+def _inner_html(dash_duo, selector: str) -> str:
+    return dash_duo.find_element(selector).get_attribute("innerHTML")
+
+
+def _wait_for_html_change(dash_duo, selector: str, previous_html: str):
+    def has_changed(driver):
+        current_html = driver.find_element(By.CSS_SELECTOR, selector).get_attribute("innerHTML")
+        return current_html if current_html != previous_html else False
+
+    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_changed)
+
+
+def _active_tab_text(driver) -> str:
+    for link in driver.find_elements(By.CSS_SELECTOR, "#tabs a"):
+        parent = link.find_element(By.XPATH, "..")
+        link_classes = link.get_attribute("class") or ""
+        parent_classes = parent.get_attribute("class") or ""
+        is_active = (
+            link.get_attribute("aria-selected") == "true"
+            or "active" in link_classes.split()
+            or "active" in parent_classes.split()
+        )
+        if is_active:
+            return link.text.strip()
+    return ""
+
+
+def _click_tab(dash_duo, label: str) -> None:
+    tabs = dash_duo.find_element("#tabs")
+    for link in tabs.find_elements(By.CSS_SELECTOR, "a"):
+        if link.text.strip().startswith(label):
+            link.click()
+            WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(
+                lambda driver: _active_tab_text(driver).startswith(label)
+            )
+            return
+    raise AssertionError(f"Could not find dashboard tab {label!r}")
+
+
+def _start_dashboard(dash_duo, dashboard_app) -> None:
+    dash_duo.start_server(dashboard_app)
+    _wait_visible(dash_duo, "#tabs")
+
+
+def test_all_dashboard_tabs_render(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    tab_content = {
+        "Overview": "#player-scoring-efficiency-table",
+        "Recent Games": "#game-selector",
+        "Team Analysis": "#team-selector",
+        "Schedule": "#schedule-table-selector",
+        "Social Media Analysis": "#social-media-team-selector",
+        "About": "h1.app-hero-title",
+    }
+
+    for label, selector in tab_content.items():
+        _click_tab(dash_duo, label)
+        _wait_visible(dash_duo, selector)
+
+    _wait_for_visible_text(dash_duo, "h1.app-hero-title", "About This Project")
+
+
+def test_overview_filter_updates_player_value_chart(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    _wait_visible(dash_duo, "#player-scoring-efficiency-table")
+    _wait_visible(dash_duo, "#team-ratings-plot .js-plotly-plot")
+    _wait_visible(dash_duo, "#player-value-analysis-plot .js-plotly-plot")
+
+    previous_html = _inner_html(dash_duo, "#player-value-analysis-plot")
+    dash_duo.select_dcc_dropdown("#player-value-team-filter", value="BOS")
+    _wait_for_html_change(dash_duo, "#player-value-analysis-plot", previous_html)
+
+
+def test_schedule_controls_update_table_and_plot(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    _click_tab(dash_duo, "Schedule")
+    _wait_visible(dash_duo, "#schedule-table .schedule-tonight-card")
+    _wait_visible(dash_duo, "#schedule-plot .js-plotly-plot")
+
+    dash_duo.select_dcc_dropdown("#schedule-table-selector", value="Full Schedule")
+    _wait_visible(dash_duo, "#schedule-full-table")
+
+    previous_html = _inner_html(dash_duo, "#schedule-plot")
+    dash_duo.select_dcc_dropdown(
+        "#schedule-plot-selector", value="Team Comebacks Analysis (Regular Season)"
+    )
+    _wait_for_html_change(dash_duo, "#schedule-plot", previous_html)
+
+
+def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    _click_tab(dash_duo, "Team Analysis")
+    _wait_visible(dash_duo, "#team-selector")
+    _wait_visible(dash_duo, "#mov-plot .js-plotly-plot")
+
+    previous_html = _inner_html(dash_duo, "#mov-plot")
+    dash_duo.select_dcc_dropdown("#team-selector", value="Los Angeles Lakers")
+    _wait_for_visible_text(dash_duo, "#kpi-boxes-1", "Team ratings")
+    _wait_for_nonempty_text(dash_duo, "#team-payroll-value")
+    _wait_for_html_change(dash_duo, "#mov-plot", previous_html)
+
+
+def test_recent_game_selection_updates_play_by_play_chart(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    _click_tab(dash_duo, "Recent Games")
+    _wait_visible(dash_duo, "#game-selector")
+    _wait_visible(dash_duo, "#pbp-analysis-plot .js-plotly-plot")
+
+    previous_html = _inner_html(dash_duo, "#pbp-analysis-plot")
+    dash_duo.select_dcc_dropdown("#game-selector", index=1)
+    _wait_for_html_change(dash_duo, "#pbp-analysis-plot", previous_html)
+
+
+def test_social_team_selection_updates_sentiment_chart(dash_duo, dashboard_app):
+    _start_dashboard(dash_duo, dashboard_app)
+
+    _click_tab(dash_duo, "Social Media Analysis")
+    _wait_visible(dash_duo, "#social-media-team-selector")
+    _wait_visible(dash_duo, "#social-media-plot .js-plotly-plot")
+
+    previous_html = _inner_html(dash_duo, "#social-media-plot")
+    dash_duo.select_dcc_dropdown("#social-media-team-selector", value="GSW")
+    _wait_for_html_change(dash_duo, "#social-media-plot", previous_html)

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -135,8 +135,9 @@ def _select_dcc_dropdown(dash_duo, selector: str, *, value: str) -> None:
         return False
 
     option = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_option)
-    # react-select v1 commits the choice on mousedown; a real click gets intercepted.
-    _dispatch_mouse_down(dash_duo, option)
+    # react-virtualized-select binds the option to onClick (not onMouseDown, as the rest of
+    # react-select does), and a real Selenium click on it gets intercepted by the overlay.
+    dash_duo.driver.execute_script("arguments[0].click();", option)
 
     WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
         lambda driver: any(

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
 import pytest
+from selenium.common.exceptions import ElementClickInterceptedException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
 pytestmark = pytest.mark.e2e
+E2E_WAIT_TIMEOUT = 30
+
+
+def _wait_timeout(dash_duo) -> int:
+    return max(dash_duo.wait_timeout, E2E_WAIT_TIMEOUT)
 
 
 def _wait_visible(dash_duo, selector: str):
-    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(
-        EC.visibility_of_element_located((By.CSS_SELECTOR, selector))
-    )
+    def find_visible(driver):
+        for element in driver.find_elements(By.CSS_SELECTOR, selector):
+            if element.is_displayed():
+                return element
+        return False
+
+    return WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_visible)
 
 
 def _wait_for_visible_text(dash_duo, selector: str, expected: str):
@@ -23,7 +32,7 @@ def _wait_for_visible_text(dash_duo, selector: str, expected: str):
                 return element
         return False
 
-    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_expected_text)
+    return WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(has_expected_text)
 
 
 def _wait_for_nonempty_text(dash_duo, selector: str):
@@ -33,7 +42,7 @@ def _wait_for_nonempty_text(dash_duo, selector: str):
             return element
         return False
 
-    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_text)
+    return WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(has_text)
 
 
 def _inner_html(dash_duo, selector: str) -> str:
@@ -45,7 +54,42 @@ def _wait_for_html_change(dash_duo, selector: str, previous_html: str):
         current_html = driver.find_element(By.CSS_SELECTOR, selector).get_attribute("innerHTML")
         return current_html if current_html != previous_html else False
 
-    return WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(has_changed)
+    return WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(has_changed)
+
+
+def _click_element(dash_duo, element) -> None:
+    dash_duo.driver.execute_script(
+        "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});", element
+    )
+    try:
+        element.click()
+    except ElementClickInterceptedException:
+        dash_duo.driver.execute_script("arguments[0].click();", element)
+
+
+def _select_dcc_dropdown(
+    dash_duo, selector: str, *, value: str | None = None, index: int | None = None
+):
+    dropdown = dash_duo.find_element(selector)
+    control = dropdown.find_element(By.CSS_SELECTOR, ".Select-control")
+    _click_element(dash_duo, control)
+
+    def find_menu(driver):
+        menus = dropdown.find_elements(By.CSS_SELECTOR, "div.Select-menu-outer")
+        for menu in menus:
+            if menu.is_displayed():
+                return menu
+        return False
+
+    menu = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_menu)
+    options = menu.find_elements(By.CSS_SELECTOR, "div.VirtualizedSelectOption")
+    if isinstance(index, int):
+        option = options[index]
+    else:
+        option = next((option for option in options if option.text == value), None)
+        if option is None:
+            raise AssertionError(f"Could not find dropdown option {value!r}")
+    _click_element(dash_duo, option)
 
 
 def _active_tab_text(driver) -> str:
@@ -67,8 +111,8 @@ def _click_tab(dash_duo, label: str) -> None:
     tabs = dash_duo.find_element("#tabs")
     for link in tabs.find_elements(By.CSS_SELECTOR, "a"):
         if link.text.strip().startswith(label):
-            link.click()
-            WebDriverWait(dash_duo.driver, dash_duo.wait_timeout).until(
+            _click_element(dash_duo, link)
+            WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
                 lambda driver: _active_tab_text(driver).startswith(label)
             )
             return
@@ -85,7 +129,7 @@ def test_all_dashboard_tabs_render(dash_duo, dashboard_app):
 
     tab_content = {
         "Overview": "#player-scoring-efficiency-table",
-        "Recent Games": "#game-selector",
+        "Recent Games": "#recent-games-card-strip .recent-games-card",
         "Team Analysis": "#team-selector",
         "Schedule": "#schedule-table-selector",
         "Social Media Analysis": "#social-media-team-selector",
@@ -107,7 +151,7 @@ def test_overview_filter_updates_player_value_chart(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#player-value-analysis-plot .js-plotly-plot")
 
     previous_html = _inner_html(dash_duo, "#player-value-analysis-plot")
-    dash_duo.select_dcc_dropdown("#player-value-team-filter", value="BOS")
+    _select_dcc_dropdown(dash_duo, "#player-value-team-filter", value="BOS")
     _wait_for_html_change(dash_duo, "#player-value-analysis-plot", previous_html)
 
 
@@ -118,12 +162,12 @@ def test_schedule_controls_update_table_and_plot(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#schedule-table .schedule-tonight-card")
     _wait_visible(dash_duo, "#schedule-plot .js-plotly-plot")
 
-    dash_duo.select_dcc_dropdown("#schedule-table-selector", value="Full Schedule")
+    _select_dcc_dropdown(dash_duo, "#schedule-table-selector", value="Full Schedule")
     _wait_visible(dash_duo, "#schedule-full-table")
 
     previous_html = _inner_html(dash_duo, "#schedule-plot")
-    dash_duo.select_dcc_dropdown(
-        "#schedule-plot-selector", value="Team Comebacks Analysis (Regular Season)"
+    _select_dcc_dropdown(
+        dash_duo, "#schedule-plot-selector", value="Team Comebacks Analysis (Regular Season)"
     )
     _wait_for_html_change(dash_duo, "#schedule-plot", previous_html)
 
@@ -136,7 +180,8 @@ def test_team_selection_updates_analysis_outputs(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#mov-plot .js-plotly-plot")
 
     previous_html = _inner_html(dash_duo, "#mov-plot")
-    dash_duo.select_dcc_dropdown("#team-selector", value="Los Angeles Lakers")
+    _select_dcc_dropdown(dash_duo, "#team-selector", value="Los Angeles Lakers")
+    _wait_for_visible_text(dash_duo, "#team-selector .Select-value-label", "Los Angeles Lakers")
     _wait_for_visible_text(dash_duo, "#kpi-boxes-1", "Team ratings")
     _wait_for_nonempty_text(dash_duo, "#team-payroll-value")
     _wait_for_html_change(dash_duo, "#mov-plot", previous_html)
@@ -146,11 +191,18 @@ def test_recent_game_selection_updates_play_by_play_chart(dash_duo, dashboard_ap
     _start_dashboard(dash_duo, dashboard_app)
 
     _click_tab(dash_duo, "Recent Games")
-    _wait_visible(dash_duo, "#game-selector")
+    _wait_visible(dash_duo, "#recent-games-card-strip .recent-games-card")
     _wait_visible(dash_duo, "#pbp-analysis-plot .js-plotly-plot")
 
     previous_html = _inner_html(dash_duo, "#pbp-analysis-plot")
-    dash_duo.select_dcc_dropdown("#game-selector", index=1)
+
+    def find_game_cards(driver):
+        cards = driver.find_elements(By.CSS_SELECTOR, "#recent-games-card-strip .recent-games-card")
+        visible_cards = [card for card in cards if card.is_displayed()]
+        return visible_cards if len(visible_cards) > 1 else False
+
+    cards = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_game_cards)
+    _click_element(dash_duo, cards[1])
     _wait_for_html_change(dash_duo, "#pbp-analysis-plot", previous_html)
 
 
@@ -162,5 +214,5 @@ def test_social_team_selection_updates_sentiment_chart(dash_duo, dashboard_app):
     _wait_visible(dash_duo, "#social-media-plot .js-plotly-plot")
 
     previous_html = _inner_html(dash_duo, "#social-media-plot")
-    dash_duo.select_dcc_dropdown("#social-media-team-selector", value="GSW")
+    _select_dcc_dropdown(dash_duo, "#social-media-team-selector", value="GSW")
     _wait_for_html_change(dash_duo, "#social-media-plot", previous_html)

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from selenium.common.exceptions import ElementClickInterceptedException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 
@@ -130,14 +131,24 @@ def _select_dcc_dropdown(
     options = WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(find_options)
     if isinstance(index, int):
         option = options[index]
+        option_index = index
         expected_label = option.text
     else:
-        option = next((option for option in options if option.text == value), None)
-        if option is None:
+        option_index, option = next(
+            (
+                (option_index, option)
+                for option_index, option in enumerate(options)
+                if option.text == value
+            ),
+            (None, None),
+        )
+        if option_index is None or option is None:
             raise AssertionError(f"Could not find dropdown option {value!r}")
         expected_label = value
 
-    _dispatch_mouse_down(dash_duo, option)
+    input_element = dropdown.find_element(By.CSS_SELECTOR, ".Select-input input")
+    input_element.send_keys(Keys.HOME, *(Keys.ARROW_DOWN for _ in range(option_index)))
+    input_element.send_keys(Keys.ENTER)
     if expected_label:
         WebDriverWait(dash_duo.driver, _wait_timeout(dash_duo)).until(
             lambda driver: any(


### PR DESCRIPTION
### Description

Add Selenium-backed Dash E2E coverage for tab rendering and core dashboard interactions, gated behind RUN_E2E=1. Configure CI to install Chromium/WebDriver and block deployment until browser tests pass.

## Added
- Six dashboard browser tests covering tabs, filters, schedule, team analysis, recent games, and social media.
- A dedicated make test-e2e target with E2E disabled by default outside explicit runs.

## Updated
- CI installs browser dependencies and runs E2E before deploy.
- Pytest collection skips E2E and integration tests appropriately when dependencies are unavailable.